### PR TITLE
2단계, 3단계, 4단계- OneToMany (EAGER, LAZY)

### DIFF
--- a/src/main/java/domain/LazyOrder.java
+++ b/src/main/java/domain/LazyOrder.java
@@ -1,0 +1,33 @@
+package domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.List;
+
+@Entity
+@Table(name = "orders")
+public class LazyOrder {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "order_number")
+    private String orderNumber;
+
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private List<OrderItem> orderItems;
+
+    public List<OrderItem> getOrderItems() {
+        return orderItems;
+    }
+}

--- a/src/main/java/domain/Order.java
+++ b/src/main/java/domain/Order.java
@@ -1,0 +1,27 @@
+package domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.List;
+
+@Entity
+@Table(name = "orders")
+public class Order {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String orderNumber;
+
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @JoinColumn(name = "order_id")
+    private List<OrderItem> orderItems;
+}

--- a/src/main/java/domain/Order.java
+++ b/src/main/java/domain/Order.java
@@ -26,4 +26,8 @@ public class Order {
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     @JoinColumn(name = "order_id")
     private List<OrderItem> orderItems;
+
+    public List<OrderItem> getOrderItems() {
+        return orderItems;
+    }
 }

--- a/src/main/java/domain/Order.java
+++ b/src/main/java/domain/Order.java
@@ -1,6 +1,7 @@
 package domain;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -19,6 +20,7 @@ public class Order {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "order_number")
     private String orderNumber;
 
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)

--- a/src/main/java/domain/OrderFixture.java
+++ b/src/main/java/domain/OrderFixture.java
@@ -1,0 +1,13 @@
+package domain;
+
+public final class OrderFixture {
+    public static final String INSERT_ORDERS =
+            "INSERT INTO orders (id, order_number) "
+                    + "VALUES (1,'first'), (2,'second')";
+    public static final String INSERT_ORDER_ITEMS =
+            "INSERT INTO order_items (id, product, quantity, order_id) "
+                    + "VALUES (1,'first_one',1,1), (2,'first_second',2,1), "
+                    + "(3,'second_three',3,2), (4,'second_four',4,2), (5,'second_five',5,2)";
+
+    private OrderFixture() {}
+}

--- a/src/main/java/domain/OrderItem.java
+++ b/src/main/java/domain/OrderItem.java
@@ -1,0 +1,19 @@
+package domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "order_items")
+public class OrderItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String product;
+
+    private Integer quantity;
+}

--- a/src/main/java/domain/OrderItem.java
+++ b/src/main/java/domain/OrderItem.java
@@ -1,5 +1,6 @@
 package domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -13,7 +14,12 @@ public class OrderItem {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "product")
     private String product;
 
+    @Column(name = "quantity")
     private Integer quantity;
+
+    @Column(name = "order_id")
+    private Long orderId;
 }

--- a/src/main/java/persistence/entity/CustomJpaRepository.java
+++ b/src/main/java/persistence/entity/CustomJpaRepository.java
@@ -9,9 +9,10 @@ public class CustomJpaRepository<T, ID> {
 
     public T save(T entity) {
         if (entityManager.isNew(entity)) {
-            entityManager.persist(entity);
-        } else if (entityManager.isDirty(entity)) {
-            entityManager.merge(entity);
+            return entityManager.persist(entity);
+        }
+        if (entityManager.isDirty(entity)) {
+            return entityManager.merge(entity);
         }
         return entity;
     }

--- a/src/main/java/persistence/entity/EagerOneToManyEntityLoader.java
+++ b/src/main/java/persistence/entity/EagerOneToManyEntityLoader.java
@@ -13,14 +13,14 @@ import java.util.Map;
 import static persistence.sql.util.StringConstant.CHILD_PREFIX;
 import static persistence.sql.util.StringConstant.PARENT_PREFIX;
 
-public class OneToManyEntityLoader<T> implements RowMapper<T> {
+public class EagerOneToManyEntityLoader<T> implements RowMapper<T> {
     private final EntityMeta parentMeta;
     private final Map<String, Field> parentFieldsByName;
     private final Map<String, Field> childFieldsByName;
     private final Map<EntityKey, T> parentObjectByKey = new HashMap<>();
 
 
-    public OneToManyEntityLoader(Class<T> clazz) {
+    public EagerOneToManyEntityLoader(Class<T> clazz) {
         this.parentMeta = new EntityMeta(clazz);
         this.parentFieldsByName = parentMeta.collectColumnFields(PARENT_PREFIX);
         this.childFieldsByName = parentMeta.getChildMeta().collectColumnFields(CHILD_PREFIX);

--- a/src/main/java/persistence/entity/EntitiesLoader.java
+++ b/src/main/java/persistence/entity/EntitiesLoader.java
@@ -1,0 +1,57 @@
+package persistence.entity;
+
+import jdbc.JdbcTemplate;
+import persistence.sql.dml.DmlBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+public class EntitiesLoader<T> {
+    private final Class<T> clazz;
+    private final EntityMeta meta;
+    private final JdbcTemplate jdbcTemplate;
+    private final DmlBuilder dml;
+
+    public EntitiesLoader(Class<T> clazz, JdbcTemplate jdbcTemplate, DmlBuilder dml) {
+        this.clazz = clazz;
+        this.meta = new EntityMeta(clazz);
+        this.jdbcTemplate = jdbcTemplate;
+        this.dml = dml;
+    }
+
+    public List<T> findAll() {
+        if (meta.isEagerOneToMany()) {
+            EagerOneToManyEntityLoader<T> loader = new EagerOneToManyEntityLoader<>(clazz);
+            jdbcTemplate.query(
+                    dml.getEagerJoinQuery(meta),
+                    loader
+            );
+            return loader.collectDistinct();
+        }
+        if (meta.isLazyOneToMany()) {
+            EntitiesLoader childrenLoader = new EntitiesLoader(meta.getChildClass(), jdbcTemplate, dml);
+            return jdbcTemplate.query(
+                    dml.getFindAllQuery(clazz),
+                    new LazyOneToManyEntityLoader<>(clazz, childrenLoader)
+            );
+        }
+        return jdbcTemplate.query(
+                dml.getFindAllQuery(clazz),
+                new EntityLoader<>(clazz)
+        );
+    }
+
+    public List<T> findAllBy(Map<String, Object> condition) {
+        if (meta.isLazyOneToMany()) {
+            EntitiesLoader childrenLoader = new EntitiesLoader(meta.getChildClass(), jdbcTemplate, dml);
+            return jdbcTemplate.query(
+                    dml.getFindAllQuery(clazz) + dml.getWhereQuery(condition),
+                    new LazyOneToManyEntityLoader<>(clazz, childrenLoader)
+            );
+        }
+        return jdbcTemplate.query(
+                dml.getFindAllQuery(clazz) + dml.getWhereQuery(condition),
+                new EntityLoader<>(clazz)
+        );
+    }
+}

--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -2,38 +2,28 @@ package persistence.entity;
 
 import jdbc.RowMapper;
 import jdbc.exception.RowMapException;
-import persistence.sql.util.ColumnFields;
-import persistence.sql.util.ColumnName;
 
 import java.lang.reflect.Field;
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class EntityLoader<T> implements RowMapper<T> {
     private final Class<T> clazz;
-    private final Map<String, Field> fieldsByName;
+    private final EntityMeta meta;
 
     public EntityLoader(Class<T> clazz) {
         this.clazz = clazz;
-        this.fieldsByName = ColumnFields.forQuery(clazz)
-                .stream().collect(Collectors.toMap(
-                        ColumnName::build,
-                        Function.identity()
-                ));
+        this.meta = new EntityMeta(clazz);
     }
 
     @Override
     public T mapRow(ResultSet resultSet) {
         try {
             final T object = clazz.getDeclaredConstructor().newInstance();
-            final ResultSetMetaData metaData = resultSet.getMetaData();
-            final int columnCount = metaData.getColumnCount();
-            for (int i = 1; i <= columnCount; i++) {
-                Field field = fieldsByName.get(metaData.getColumnLabel(i));
-                Object value = resultSet.getObject(metaData.getColumnName(i));
+            for (Map.Entry<String, Field> entry : meta.collectColumnFields().entrySet()) {
+                String columnName = entry.getKey();
+                Field field = entry.getValue();
+                Object value = resultSet.getObject(columnName);
                 field.setAccessible(true);
                 field.set(object, value);
             }

--- a/src/main/java/persistence/entity/EntityManager.java
+++ b/src/main/java/persistence/entity/EntityManager.java
@@ -8,11 +8,11 @@ public interface EntityManager {
 
     <T> Optional<T> find(Class<T> clazz, Object id);
 
-    void persist(Object entity);
+    <T> T persist(T entity);
+
+    <T> T merge(T entity);
 
     void remove(Object entity);
-
-    void merge(Object entity);
 
     void detach(Object entity);
 

--- a/src/main/java/persistence/entity/EntityManager.java
+++ b/src/main/java/persistence/entity/EntityManager.java
@@ -1,8 +1,11 @@
 package persistence.entity;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface EntityManager {
+    <T> List<T> findAll(Class<T> clazz);
+
     <T> Optional<T> find(Class<T> clazz, Object id);
 
     void persist(Object entity);

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -18,6 +18,21 @@ public class EntityManagerImpl implements EntityManager {
     }
 
     @Override
+    public <T> List<T> findAll(Class<T> clazz) {
+        EntityMeta meta = new EntityMeta(clazz);
+        if (meta.isOneToMany()) {
+            return jdbcTemplate.query(
+                    dml.getEagerJoinQuery(meta),
+                    new EntityLoader<>(clazz)
+            );
+        }
+        return jdbcTemplate.query(
+                dml.getFindAllQuery(clazz),
+                new EntityLoader<>(clazz)
+        );
+    }
+
+    @Override
     public <T> Optional<T> find(Class<T> clazz, Object id) {
         EntityKey<T> key = new EntityKey<>(clazz, id);
         if (!context.hasEntity(key)) {

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -20,8 +20,8 @@ public class EntityManagerImpl implements EntityManager {
     @Override
     public <T> List<T> findAll(Class<T> clazz) {
         EntityMeta meta = new EntityMeta(clazz);
-        if (meta.isOneToMany()) {
-            OneToManyEntityLoader<T> loader = new OneToManyEntityLoader<>(clazz);
+        if (meta.isEagerOneToMany()) {
+            EagerOneToManyEntityLoader<T> loader = new EagerOneToManyEntityLoader<>(clazz);
             jdbcTemplate.query(
                     dml.getEagerJoinQuery(meta),
                     loader

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -19,19 +19,7 @@ public class EntityManagerImpl implements EntityManager {
 
     @Override
     public <T> List<T> findAll(Class<T> clazz) {
-        EntityMeta meta = new EntityMeta(clazz);
-        if (meta.isEagerOneToMany()) {
-            EagerOneToManyEntityLoader<T> loader = new EagerOneToManyEntityLoader<>(clazz);
-            jdbcTemplate.query(
-                    dml.getEagerJoinQuery(meta),
-                    loader
-            );
-            return loader.collectDistinct();
-        }
-        return jdbcTemplate.query(
-                dml.getFindAllQuery(clazz),
-                new EntityLoader<>(clazz)
-        );
+        return new EntitiesLoader(clazz, jdbcTemplate, dml).findAll();
     }
 
     @Override

--- a/src/main/java/persistence/entity/EntityManagerImpl.java
+++ b/src/main/java/persistence/entity/EntityManagerImpl.java
@@ -21,10 +21,12 @@ public class EntityManagerImpl implements EntityManager {
     public <T> List<T> findAll(Class<T> clazz) {
         EntityMeta meta = new EntityMeta(clazz);
         if (meta.isOneToMany()) {
-            return jdbcTemplate.query(
+            OneToManyEntityLoader<T> loader = new OneToManyEntityLoader<>(clazz);
+            jdbcTemplate.query(
                     dml.getEagerJoinQuery(meta),
-                    new EntityLoader<>(clazz)
+                    loader
             );
+            return loader.collectDistinct();
         }
         return jdbcTemplate.query(
                 dml.getFindAllQuery(clazz),

--- a/src/main/java/persistence/entity/EntityMeta.java
+++ b/src/main/java/persistence/entity/EntityMeta.java
@@ -1,6 +1,7 @@
 package persistence.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
@@ -133,7 +134,7 @@ public class EntityMeta {
     }
 
     public void initOneToMany(Object obj) throws IllegalAccessException {
-        if (!isOneToMany()) {
+        if (!isEagerOneToMany()) {
             return;
         }
         fkField.setAccessible(true);
@@ -141,7 +142,7 @@ public class EntityMeta {
     }
 
     public void addChild(Object parent, Object child) throws IllegalAccessException {
-        if (!isOneToMany()) {
+        if (!isEagerOneToMany()) {
             return;
         }
         ((List) fkField.get(parent)).add(child);
@@ -163,10 +164,13 @@ public class EntityMeta {
         return childMeta;
     }
 
-    public boolean isOneToMany() {
-        return getFkName() != null
-                && childClass != null
-                && childMeta != null;
+    public boolean isEagerOneToMany() {
+        if (fkField == null || childClass == null || childMeta == null) {
+            return false;
+        }
+        OneToMany annotation = fkField.getDeclaredAnnotation(OneToMany.class);
+        return annotation != null
+                && annotation.fetch() == FetchType.EAGER;
     }
 
     private String format(String prefix, Field field) {

--- a/src/main/java/persistence/entity/EntityMeta.java
+++ b/src/main/java/persistence/entity/EntityMeta.java
@@ -1,0 +1,142 @@
+package persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import persistence.exception.ChildClassNotFoundException;
+import persistence.sql.exception.EntityIdNotFoundException;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class EntityMeta {
+    private final String tableName;
+    private final List<String> columnNames;
+    private final String pkName;
+    private final String fkName;
+    private final Class childClass;
+    private final EntityMeta childMeta;
+
+    public EntityMeta(Class clazz) {
+        this.tableName = findTableName(clazz);
+        this.pkName = findPkName(clazz);
+        this.fkName = findFkName(clazz);
+        this.columnNames = findColumnNames(clazz);
+        this.childClass = findChildClass(clazz);
+        this.childMeta = childClass == null
+                ? null : new EntityMeta(childClass);
+    }
+
+    private static <T> String findTableName(Class<T> clazz) {
+        Table table = clazz.getDeclaredAnnotation(Table.class);
+        return table == null || table.name().isBlank()
+                ? clazz.getSimpleName()
+                : table.name();
+    }
+
+    private static List<String> findColumnNames(Class clazz) {
+        return Arrays.stream(clazz.getDeclaredFields())
+                .filter(
+                        field -> !field.isAnnotationPresent(Transient.class)
+                                && !field.isAnnotationPresent(OneToMany.class)
+                ).map(EntityMeta::findColumnName)
+                .collect(Collectors.toList());
+    }
+
+    private static String findColumnName(Field field) {
+        final Column column = field.getDeclaredAnnotation(Column.class);
+        return column == null || column.name().isBlank()
+                ? field.getName()
+                : column.name();
+    }
+
+    private static String findPkName(Class clazz) {
+        return Arrays.stream(clazz.getDeclaredFields())
+                .filter(field -> field.isAnnotationPresent(Id.class))
+                .findAny()
+                .map(EntityMeta::findColumnName)
+                .orElseThrow(() -> new EntityIdNotFoundException());
+    }
+
+    private static String findFkName(Class clazz) {
+        return Arrays.stream(clazz.getDeclaredFields())
+                .filter(field -> field.isAnnotationPresent(JoinColumn.class))
+                .findAny()
+                .map(field -> field.getDeclaredAnnotation(JoinColumn.class).name())
+                .orElse(null);
+    }
+
+    private static Class findChildClass(Class clazz) {
+        return Arrays.stream(clazz.getDeclaredFields())
+                .filter(field -> field.isAnnotationPresent(OneToMany.class))
+                .findAny()
+                .map(EntityMeta::findGenericType)
+                .orElse(null);
+    }
+
+    private static Class findGenericType(Field childField) {
+        Type type = childField.getGenericType();
+        if (!(type instanceof ParameterizedType)) {
+            return null;
+        }
+        ParameterizedType parameterizedType = (ParameterizedType) type;
+        Type[] typeArguments = parameterizedType.getActualTypeArguments();
+        if (typeArguments == null || typeArguments.length == 0) {
+            return null;
+        }
+        try {
+            return Class.forName(typeArguments[0].getTypeName());
+        } catch (ClassNotFoundException e) {
+            throw new ChildClassNotFoundException(e);
+        }
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public List<String> getColumnNames() {
+        return columnNames;
+    }
+
+    public String joinColumnNames(String prefix) {
+        return getColumnNames().stream().map(
+                columnName -> String.format("%s.%s", prefix, columnName)
+        ).collect(Collectors.joining(", "));
+    }
+
+    public String getPkName() {
+        return pkName;
+    }
+
+    public String getFkName() {
+        return fkName;
+    }
+
+    public String getFKCondition(String parentPrefix, String childPrefix) {
+        return new StringBuilder()
+                .append(parentPrefix)
+                .append(".")
+                .append(pkName)
+                .append(" = ")
+                .append(childPrefix)
+                .append(".")
+                .append(fkName)
+                .toString();
+    }
+
+    public Class getChildClass() {
+        return childClass;
+    }
+
+    public EntityMeta getChildMeta() {
+        return childMeta;
+    }
+}

--- a/src/main/java/persistence/entity/EntityMeta.java
+++ b/src/main/java/persistence/entity/EntityMeta.java
@@ -16,7 +16,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static persistence.sql.util.StringConstant.DELIMITER;
+
 public class EntityMeta {
+    private final Class parentClass;
     private final String tableName;
     private final List<String> columnNames;
     private final String pkName;
@@ -25,6 +28,7 @@ public class EntityMeta {
     private final EntityMeta childMeta;
 
     public EntityMeta(Class clazz) {
+        this.parentClass = clazz;
         this.tableName = findTableName(clazz);
         this.pkName = findPkName(clazz);
         this.fkName = findFkName(clazz);
@@ -98,6 +102,10 @@ public class EntityMeta {
         }
     }
 
+    public Class getParentClass() {
+        return parentClass;
+    }
+
     public String getTableName() {
         return tableName;
     }
@@ -108,8 +116,8 @@ public class EntityMeta {
 
     public String joinColumnNames(String prefix) {
         return getColumnNames().stream().map(
-                columnName -> String.format("%s.%s", prefix, columnName)
-        ).collect(Collectors.joining(", "));
+                columnName -> formatColumn(prefix, columnName)
+        ).collect(Collectors.joining(DELIMITER));
     }
 
     public String getPkName() {
@@ -122,13 +130,9 @@ public class EntityMeta {
 
     public String getFKCondition(String parentPrefix, String childPrefix) {
         return new StringBuilder()
-                .append(parentPrefix)
-                .append(".")
-                .append(pkName)
+                .append(formatColumn(parentPrefix, pkName))
                 .append(" = ")
-                .append(childPrefix)
-                .append(".")
-                .append(fkName)
+                .append(formatColumn(childPrefix, fkName))
                 .toString();
     }
 
@@ -138,5 +142,15 @@ public class EntityMeta {
 
     public EntityMeta getChildMeta() {
         return childMeta;
+    }
+
+    public boolean isOneToMany() {
+        return fkName != null
+                && childClass != null
+                && childMeta != null;
+    }
+
+    private String formatColumn(String prefix, String columnName) {
+        return String.format("%s.%s", prefix, columnName);
     }
 }

--- a/src/main/java/persistence/entity/LazyOneToManyEntityLoader.java
+++ b/src/main/java/persistence/entity/LazyOneToManyEntityLoader.java
@@ -1,0 +1,70 @@
+package persistence.entity;
+
+import jdbc.RowMapper;
+import jdbc.exception.RowMapException;
+import net.sf.cglib.proxy.Enhancer;
+import net.sf.cglib.proxy.LazyLoader;
+
+import java.lang.reflect.Field;
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.Map;
+
+public class LazyOneToManyEntityLoader<T> implements RowMapper<T> {
+    private final EntityMeta meta;
+    private final EntitiesLoader childrenLoader;
+
+    public LazyOneToManyEntityLoader(Class clazz, EntitiesLoader childrenLoader) {
+        this.meta = new EntityMeta(clazz);
+        this.childrenLoader = childrenLoader;
+    }
+
+    @Override
+    public T mapRow(ResultSet resultSet) {
+        T object = createObject(resultSet);
+        setProxy(object);
+        return object;
+    }
+
+    private T createObject(ResultSet resultSet) {
+        try {
+            final T object = (T) meta.getParentClass().getDeclaredConstructor().newInstance();
+            for (Map.Entry<String, Field> entry : meta.collectColumnFields().entrySet()) {
+                String columnName = entry.getKey();
+                Field field = entry.getValue();
+                Object value = resultSet.getObject(columnName);
+                field.setAccessible(true);
+                field.set(object, value);
+            }
+            return object;
+        } catch (Exception e) {
+            throw new RowMapException(e);
+        }
+    }
+
+    private void setProxy(T object) {
+        Field fkField = meta.getFkField();
+        try {
+            Enhancer enhancer = getEnhancerForChild(object);
+            fkField.setAccessible(true);
+            fkField.set(object, enhancer.create());
+        } catch (IllegalAccessException e) {
+            throw new RowMapException(e);
+        }
+    }
+
+    private Enhancer getEnhancerForChild(T object) throws IllegalAccessException {
+        Enhancer enhancer = new Enhancer();
+        enhancer.setSuperclass(List.class);
+        Field pkField = meta.getPkField();
+        pkField.setAccessible(true);
+        Map<String, Object> condition = Map.of(
+                meta.getFkName(),
+                pkField.get(object)
+        );
+        enhancer.setCallback(
+                (LazyLoader) () -> childrenLoader.findAllBy(condition)
+        );
+        return enhancer;
+    }
+}

--- a/src/main/java/persistence/entity/OneToManyEntityLoader.java
+++ b/src/main/java/persistence/entity/OneToManyEntityLoader.java
@@ -1,0 +1,83 @@
+package persistence.entity;
+
+import jdbc.RowMapper;
+import jdbc.exception.RowMapException;
+
+import java.lang.reflect.Field;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static persistence.sql.util.StringConstant.CHILD_PREFIX;
+import static persistence.sql.util.StringConstant.PARENT_PREFIX;
+
+public class OneToManyEntityLoader<T> implements RowMapper<T> {
+    private final EntityMeta parentMeta;
+    private final Map<String, Field> parentFieldsByName;
+    private final Map<String, Field> childFieldsByName;
+    private final Map<EntityKey, T> parentObjectByKey = new HashMap<>();
+
+
+    public OneToManyEntityLoader(Class<T> clazz) {
+        this.parentMeta = new EntityMeta(clazz);
+        this.parentFieldsByName = parentMeta.collectColumnFields(PARENT_PREFIX);
+        this.childFieldsByName = parentMeta.getChildMeta().collectColumnFields(CHILD_PREFIX);
+    }
+
+    public List<T> collectDistinct() {
+        return new ArrayList<>(parentObjectByKey.values());
+    }
+
+    @Override
+    public T mapRow(ResultSet resultSet) {
+        try {
+            Object parent = createParent(resultSet);
+            addChild(resultSet, parent);
+            return (T) parent;
+        } catch (Exception e) {
+            throw new RowMapException(e);
+        }
+    }
+
+    private T createParent(ResultSet resultSet) throws Exception {
+        T parent = (T) createObject(
+                parentMeta,
+                parentFieldsByName,
+                resultSet
+        );
+        EntityKey key = new EntityKey(parent);
+        if (parentObjectByKey.get(key) == null) {
+            parentObjectByKey.put(key, parent);
+        }
+        return parentObjectByKey.get(key);
+    }
+
+    private void addChild(ResultSet resultSet, Object parent) throws Exception {
+        Object child = createObject(
+                parentMeta.getChildMeta(),
+                childFieldsByName,
+                resultSet
+        );
+        parentMeta.addChild(parent, child);
+    }
+
+    private Object createObject(
+            EntityMeta meta,
+            Map<String, Field> fieldsByName,
+            ResultSet resultSet
+    ) throws Exception {
+        final Object obj = meta.getParentClass()
+                .getDeclaredConstructor()
+                .newInstance();
+        for (Map.Entry<String, Field> entry : fieldsByName.entrySet()) {
+            String columnName = entry.getKey();
+            Field field = entry.getValue();
+            field.setAccessible(true);
+            field.set(obj, resultSet.getObject(columnName));
+        }
+        meta.initOneToMany(obj);
+        return obj;
+    }
+}

--- a/src/main/java/persistence/exception/ChildClassNotFoundException.java
+++ b/src/main/java/persistence/exception/ChildClassNotFoundException.java
@@ -1,0 +1,7 @@
+package persistence.exception;
+
+public class ChildClassNotFoundException extends RuntimeException {
+    public ChildClassNotFoundException(ClassNotFoundException e) {
+        super(e);
+    }
+}

--- a/src/main/java/persistence/sql/dml/DmlBuilder.java
+++ b/src/main/java/persistence/sql/dml/DmlBuilder.java
@@ -1,13 +1,17 @@
 package persistence.sql.dml;
 
+import persistence.entity.EntityMeta;
+
 public interface DmlBuilder {
     String getInsertQuery(Object entity);
 
-    String getFindAllQuery(Class<?> clazz);
+    String getEagerJoinQuery(EntityMeta clazz);
 
-    String getFindByIdQuery(Class<?> clazz, Object id);
+    String getFindAllQuery(Class clazz);
 
-    String getDeleteByIdQuery(Class<?> clazz, Object id);
+    String getFindByIdQuery(Class clazz, Object id);
+
+    String getDeleteByIdQuery(Class clazz, Object id);
 
     String getUpdateQuery(Object entity);
 }

--- a/src/main/java/persistence/sql/dml/DmlBuilder.java
+++ b/src/main/java/persistence/sql/dml/DmlBuilder.java
@@ -2,12 +2,16 @@ package persistence.sql.dml;
 
 import persistence.entity.EntityMeta;
 
+import java.util.Map;
+
 public interface DmlBuilder {
     String getInsertQuery(Object entity);
 
     String getEagerJoinQuery(EntityMeta clazz);
 
     String getFindAllQuery(Class clazz);
+
+    String getWhereQuery(Map<String, Object> condition);
 
     String getFindByIdQuery(Class clazz, Object id);
 

--- a/src/main/java/persistence/sql/dml/h2/H2DmlBuilder.java
+++ b/src/main/java/persistence/sql/dml/h2/H2DmlBuilder.java
@@ -3,6 +3,8 @@ package persistence.sql.dml.h2;
 import persistence.entity.EntityMeta;
 import persistence.sql.dml.DmlBuilder;
 
+import java.util.Map;
+
 public final class H2DmlBuilder implements DmlBuilder {
     private H2DmlBuilder() {}
 
@@ -23,6 +25,11 @@ public final class H2DmlBuilder implements DmlBuilder {
     @Override
     public String getFindAllQuery(Class clazz) {
         return H2FindAllQuery.build(clazz);
+    }
+
+    @Override
+    public String getWhereQuery(Map<String, Object> condition) {
+        return H2WhereQuery.build(condition);
     }
 
     @Override

--- a/src/main/java/persistence/sql/dml/h2/H2DmlBuilder.java
+++ b/src/main/java/persistence/sql/dml/h2/H2DmlBuilder.java
@@ -1,5 +1,6 @@
 package persistence.sql.dml.h2;
 
+import persistence.entity.EntityMeta;
 import persistence.sql.dml.DmlBuilder;
 
 public final class H2DmlBuilder implements DmlBuilder {
@@ -15,17 +16,22 @@ public final class H2DmlBuilder implements DmlBuilder {
     }
 
     @Override
-    public String getFindAllQuery(Class<?> clazz) {
+    public String getEagerJoinQuery(EntityMeta meta) {
+        return H2EagerJoinQuery.build(meta);
+    }
+
+    @Override
+    public String getFindAllQuery(Class clazz) {
         return H2FindAllQuery.build(clazz);
     }
 
     @Override
-    public String getFindByIdQuery(Class<?> clazz, Object id) {
+    public String getFindByIdQuery(Class clazz, Object id) {
         return H2FindByIdQuery.build(clazz, id);
     }
 
     @Override
-    public String getDeleteByIdQuery(Class<?> clazz, Object id) {
+    public String getDeleteByIdQuery(Class clazz, Object id) {
         return H2DeleteByIdQuery.build(clazz, id);
     }
 

--- a/src/main/java/persistence/sql/dml/h2/H2EagerJoinQuery.java
+++ b/src/main/java/persistence/sql/dml/h2/H2EagerJoinQuery.java
@@ -1,0 +1,34 @@
+package persistence.sql.dml.h2;
+
+import persistence.entity.EntityMeta;
+
+import static persistence.sql.util.StringConstant.CHILD_PREFIX;
+import static persistence.sql.util.StringConstant.DELIMITER;
+import static persistence.sql.util.StringConstant.PARENT_PREFIX;
+
+public final class H2EagerJoinQuery {
+    private H2EagerJoinQuery() {}
+
+    public static String build(EntityMeta meta) {
+        return new StringBuilder()
+                .append("SELECT ")
+                .append(buildColumnNames(meta))
+                .append(" FROM ")
+                .append(buildTableName(meta, PARENT_PREFIX))
+                .append(" INNER JOIN ")
+                .append(buildTableName(meta.getChildMeta(), CHILD_PREFIX))
+                .append(" ON ")
+                .append(meta.getFKCondition(PARENT_PREFIX, CHILD_PREFIX))
+                .toString();
+    }
+
+    private static String buildColumnNames(EntityMeta meta) {
+        return meta.joinColumnNames(PARENT_PREFIX)
+                + DELIMITER
+                + meta.getChildMeta().joinColumnNames(CHILD_PREFIX);
+    }
+
+    private static String buildTableName(EntityMeta meta, String prefix) {
+        return meta.getTableName() + " AS " + prefix;
+    }
+}

--- a/src/main/java/persistence/sql/dml/h2/H2WhereQuery.java
+++ b/src/main/java/persistence/sql/dml/h2/H2WhereQuery.java
@@ -1,0 +1,29 @@
+package persistence.sql.dml.h2;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static persistence.sql.util.StringConstant.DELIMITER;
+
+public final class H2WhereQuery {
+    private H2WhereQuery() {}
+
+    public static String build(Map<String, Object> condition) {
+        return new StringBuilder()
+                .append(" WHERE ")
+                .append(condition.entrySet().stream().map(
+                        entry -> String.format(
+                                "%s = %s",
+                                entry.getKey(),
+                                toString(entry.getValue())
+                        )
+                ).collect(Collectors.joining(DELIMITER)))
+                .toString();
+    }
+
+    private static String toString(Object value) {
+        return (value instanceof String)
+                ? String.format("'%s'", value)
+                : value.toString();
+    }
+}

--- a/src/main/java/persistence/sql/util/ColumnConditions.java
+++ b/src/main/java/persistence/sql/util/ColumnConditions.java
@@ -2,9 +2,9 @@ package persistence.sql.util;
 
 import java.util.stream.Collectors;
 
-public final class ColumnConditions {
-    private static final String DELIMITER = ", ";
+import static persistence.sql.util.StringConstant.DELIMITER;
 
+public final class ColumnConditions {
     private ColumnConditions() {}
 
     public static String forUpsert(Object entity) {

--- a/src/main/java/persistence/sql/util/ColumnFields.java
+++ b/src/main/java/persistence/sql/util/ColumnFields.java
@@ -1,6 +1,7 @@
 package persistence.sql.util;
 
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Transient;
 
 import java.lang.reflect.Field;
@@ -15,6 +16,7 @@ public final class ColumnFields {
         return Arrays.stream(clazz.getDeclaredFields())
                 .filter(
                         field -> !field.isAnnotationPresent(Transient.class)
+                                && !field.isAnnotationPresent(OneToMany.class)
                 ).collect(Collectors.toList());
     }
 

--- a/src/main/java/persistence/sql/util/StringConstant.java
+++ b/src/main/java/persistence/sql/util/StringConstant.java
@@ -2,7 +2,10 @@ package persistence.sql.util;
 
 public final class StringConstant {
     public static final String BLANK = "";
+    public static final String DOT = ".";
     public static final String DELIMITER = ", ";
+    public static final String PARENT_PREFIX = "t1";
+    public static final String CHILD_PREFIX = "t2";
 
     private StringConstant() {}
 }

--- a/src/main/java/proxy/Hello.java
+++ b/src/main/java/proxy/Hello.java
@@ -1,0 +1,11 @@
+package proxy;
+
+public interface Hello {
+    String sayHello(String name);
+
+    String sayHi(String name);
+
+    String sayThankYou(String name);
+
+    String pingPong(String name);
+}

--- a/src/main/java/proxy/HelloTarget.java
+++ b/src/main/java/proxy/HelloTarget.java
@@ -1,0 +1,23 @@
+package proxy;
+
+class HelloTarget implements Hello {
+    @Override
+    public String sayHello(String name) {
+        return "Hello " + name;
+    }
+
+    @Override
+    public String sayHi(String name) {
+        return "Hi " + name;
+    }
+
+    @Override
+    public String sayThankYou(String name) {
+        return "Thank You " + name;
+    }
+
+    @Override
+    public String pingPong(String name) {
+        return "Pong " + name;
+    }
+}

--- a/src/test/java/persistence/entity/EntityManagerImplTest.java
+++ b/src/test/java/persistence/entity/EntityManagerImplTest.java
@@ -18,7 +18,9 @@ import persistence.sql.dialect.Dialect;
 import persistence.sql.dml.DmlBuilder;
 
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -106,6 +108,10 @@ class EntityManagerImplTest {
     @DisplayName("OneToMany 관계에 있는 엔티티를 객체화 할 수 있다.")
     void oneToMany() {
         List<Order> orders = entityManager.findAll(Order.class);
-        assertThat(orders).isNotEmpty();
+        List<OrderItem> orderItems = orders.stream()
+                .map(Order::getOrderItems)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+        assertThat(orderItems).isNotEmpty();
     }
 }

--- a/src/test/java/persistence/entity/EntityManagerImplTest.java
+++ b/src/test/java/persistence/entity/EntityManagerImplTest.java
@@ -2,6 +2,8 @@ package persistence.entity;
 
 import database.DatabaseServer;
 import database.H2;
+import domain.Order;
+import domain.OrderItem;
 import domain.Person;
 import domain.PersonFixture;
 import jdbc.JdbcTemplate;
@@ -15,6 +17,7 @@ import persistence.sql.dialect.Dialect;
 import persistence.sql.dml.DmlBuilder;
 
 import java.sql.SQLException;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,12 +48,14 @@ class EntityManagerImplTest {
 
     @BeforeEach
     void setUp() {
-        jdbcTemplate.execute(
-                ddl.getDropQuery(Person.class)
-        );
-        jdbcTemplate.execute(
+        List.of(
+                ddl.getDropQuery(Person.class),
+                ddl.getDropQuery(OrderItem.class),
+                ddl.getDropQuery(Order.class),
+                ddl.getCreateQuery(Order.class),
+                ddl.getCreateQuery(OrderItem.class),
                 ddl.getCreateQuery(Person.class)
-        );
+        ).forEach(jdbcTemplate::execute);
         entityManager = new EntityManagerImpl(
                 new StatefulPersistenceContext(),
                 jdbcTemplate, dml

--- a/src/test/java/persistence/entity/EntityManagerImplTest.java
+++ b/src/test/java/persistence/entity/EntityManagerImplTest.java
@@ -82,11 +82,10 @@ class EntityManagerImplTest {
         entityManager.persist(person);
         entityManager.remove(person);
         assertThat(
-                entityManager.find(
-                        person.getClass(),
-                        personId
-                ).isPresent()
-        ).isFalse();
+                entityManager.findAll(
+                        person.getClass()
+                ).isEmpty()
+        ).isTrue();
     }
 
     @Test

--- a/src/test/java/persistence/entity/EntityManagerImplTest.java
+++ b/src/test/java/persistence/entity/EntityManagerImplTest.java
@@ -2,6 +2,7 @@ package persistence.entity;
 
 import database.DatabaseServer;
 import database.H2;
+import domain.LazyOrder;
 import domain.Order;
 import domain.OrderFixture;
 import domain.OrderItem;
@@ -105,11 +106,22 @@ class EntityManagerImplTest {
     }
 
     @Test
-    @DisplayName("OneToMany 관계에 있는 엔티티를 객체화 할 수 있다.")
-    void oneToMany() {
+    @DisplayName("Eager OneToMany 관계에 있는 엔티티를 객체화 할 수 있다.")
+    void eagerOneToMany() {
         List<Order> orders = entityManager.findAll(Order.class);
         List<OrderItem> orderItems = orders.stream()
                 .map(Order::getOrderItems)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+        assertThat(orderItems).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("Lazy OneToMany 관계에 있는 엔티티를 객체화 할 수 있다.")
+    void lazyOneToMany() {
+        List<LazyOrder> orders = entityManager.findAll(LazyOrder.class);
+        List<OrderItem> orderItems = orders.stream()
+                .map(LazyOrder::getOrderItems)
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
         assertThat(orderItems).isNotEmpty();

--- a/src/test/java/persistence/entity/EntityManagerImplTest.java
+++ b/src/test/java/persistence/entity/EntityManagerImplTest.java
@@ -3,6 +3,7 @@ package persistence.entity;
 import database.DatabaseServer;
 import database.H2;
 import domain.Order;
+import domain.OrderFixture;
 import domain.OrderItem;
 import domain.Person;
 import domain.PersonFixture;
@@ -56,6 +57,8 @@ class EntityManagerImplTest {
                 ddl.getCreateQuery(OrderItem.class),
                 ddl.getCreateQuery(Person.class)
         ).forEach(jdbcTemplate::execute);
+        jdbcTemplate.execute(OrderFixture.INSERT_ORDERS);
+        jdbcTemplate.execute(OrderFixture.INSERT_ORDER_ITEMS);
         entityManager = new EntityManagerImpl(
                 new StatefulPersistenceContext(),
                 jdbcTemplate, dml
@@ -97,5 +100,12 @@ class EntityManagerImplTest {
         assertThat(
                 entityManager.isDirty(person)
         ).isTrue();
+    }
+
+    @Test
+    @DisplayName("OneToMany 관계에 있는 엔티티를 객체화 할 수 있다.")
+    void oneToMany() {
+        List<Order> orders = entityManager.findAll(Order.class);
+        assertThat(orders).isNotEmpty();
     }
 }

--- a/src/test/java/persistence/entity/EntityMetaTest.java
+++ b/src/test/java/persistence/entity/EntityMetaTest.java
@@ -1,0 +1,97 @@
+package persistence.entity;
+
+import domain.Order;
+import domain.OrderItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class EntityMetaTest {
+    private EntityMeta meta;
+
+    @BeforeEach
+    void setUp() {
+        meta = new EntityMeta(Order.class);
+    }
+
+
+    @DisplayName("테이블 이름 정보를 가져올 수 있다.")
+    @Test
+    void getTableName() {
+        assertThat(meta.getTableName())
+                .isEqualTo("orders");
+    }
+
+    @DisplayName("칼럼 이름 정보들을 가져올 수 있다.")
+    @Test
+    void getColumnNames() {
+        assertThat(meta.getColumnNames())
+                .isEqualTo(List.of(
+                        "id",
+                        "order_number"
+                ));
+    }
+
+    @DisplayName("칼럼 이름들을 조합해서 하나의 String 으로 만들 수 있다.")
+    @Test
+    void joinColumnNames() {
+        assertThat(meta.joinColumnNames("t1"))
+                .isEqualTo("t1.id, t1.order_number");
+    }
+
+    @DisplayName("테이블의 PK 이름을 가져올 수 있다.")
+    @Test
+    void getPkName() {
+        assertThat(meta.getPkName())
+                .isEqualTo("id");
+    }
+
+    @DisplayName("테이블의 FK 이름을 가져올 수 있다.")
+    @Test
+    void getFkName() {
+        assertThat(meta.getFkName())
+                .isEqualTo("order_id");
+    }
+
+    @DisplayName("테이블 조인을 위한 조건문을 가져올 수 있다.")
+    @Test
+    void getFkCondition() {
+        assertThat(meta.getFKCondition("t1", "t2"))
+                .isEqualTo("t1.id = t2.order_id");
+    }
+
+    @DisplayName("조인되는 자식의 클래스 정보를 가져올 수 있다.")
+    @Test
+    void getChildClass() {
+        assertThat(meta.getChildClass())
+                .isEqualTo(OrderItem.class);
+    }
+
+    @DisplayName("조인되는 자식의 클래스 정보를 Meta 객체 형태로 가공할 수 있다.")
+    @Test
+    void getChildMeta() {
+        EntityMeta childMeta = meta.getChildMeta();
+        assertAll(
+                () -> assertThat(childMeta.getTableName())
+                        .isEqualTo("order_items"),
+                () -> assertThat(childMeta.getColumnNames())
+                        .isEqualTo(List.of(
+                                "id",
+                                "product",
+                                "quantity",
+                                "order_id"
+                        )),
+                () -> assertThat(childMeta.joinColumnNames("t2"))
+                        .isEqualTo("t2.id, t2.product, t2.quantity, t2.order_id"),
+                () -> assertThat(childMeta.getPkName())
+                        .isEqualTo("id"),
+                () -> assertThat(childMeta.getFkName())
+                        .isEqualTo(null)
+        );
+    }
+}

--- a/src/test/java/persistence/entity/EntityMetaTest.java
+++ b/src/test/java/persistence/entity/EntityMetaTest.java
@@ -70,7 +70,7 @@ class EntityMetaTest {
     @DisplayName("조인 쿼리를 생성할 수 있는지 여부를 알 수 있다.")
     @Test
     void isOneToMany() {
-        assertThat(meta.isOneToMany())
+        assertThat(meta.isEagerOneToMany())
                 .isTrue();
     }
 
@@ -87,7 +87,7 @@ class EntityMetaTest {
                         .isEqualTo("id"),
                 () -> assertThat(childMeta.getFkName())
                         .isEqualTo(null),
-                () -> assertThat(childMeta.isOneToMany())
+                () -> assertThat(childMeta.isEagerOneToMany())
                         .isFalse()
         );
     }

--- a/src/test/java/persistence/entity/EntityMetaTest.java
+++ b/src/test/java/persistence/entity/EntityMetaTest.java
@@ -6,8 +6,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -34,21 +32,11 @@ class EntityMetaTest {
                 .isEqualTo("orders");
     }
 
-    @DisplayName("칼럼 이름 정보들을 가져올 수 있다.")
-    @Test
-    void getColumnNames() {
-        assertThat(meta.getColumnNames())
-                .isEqualTo(List.of(
-                        "id",
-                        "order_number"
-                ));
-    }
-
-    @DisplayName("칼럼 이름들을 조합해서 하나의 String 으로 만들 수 있다.")
+    @DisplayName("칼럼 이름과 별명을 조합해서 하나의 String 으로 만들 수 있다.")
     @Test
     void joinColumnNames() {
         assertThat(meta.joinColumnNames("t1"))
-                .isEqualTo("t1.id, t1.order_number");
+                .isEqualTo("t1.id AS t1_id, t1.order_number AS t1_order_number");
     }
 
     @DisplayName("테이블의 PK 이름을 가져올 수 있다.")
@@ -93,15 +81,8 @@ class EntityMetaTest {
         assertAll(
                 () -> assertThat(childMeta.getTableName())
                         .isEqualTo("order_items"),
-                () -> assertThat(childMeta.getColumnNames())
-                        .isEqualTo(List.of(
-                                "id",
-                                "product",
-                                "quantity",
-                                "order_id"
-                        )),
                 () -> assertThat(childMeta.joinColumnNames("t2"))
-                        .isEqualTo("t2.id, t2.product, t2.quantity, t2.order_id"),
+                        .isEqualTo("t2.id AS t2_id, t2.product AS t2_product, t2.quantity AS t2_quantity, t2.order_id AS t2_order_id"),
                 () -> assertThat(childMeta.getPkName())
                         .isEqualTo("id"),
                 () -> assertThat(childMeta.getFkName())

--- a/src/test/java/persistence/entity/EntityMetaTest.java
+++ b/src/test/java/persistence/entity/EntityMetaTest.java
@@ -20,6 +20,13 @@ class EntityMetaTest {
     }
 
 
+    @DisplayName("부모 엔티티 클래스 정보를 가져올 수 있다.")
+    @Test
+    void getParentClass() {
+        assertThat(meta.getParentClass())
+                .isEqualTo(Order.class);
+    }
+
     @DisplayName("테이블 이름 정보를 가져올 수 있다.")
     @Test
     void getTableName() {
@@ -72,6 +79,13 @@ class EntityMetaTest {
                 .isEqualTo(OrderItem.class);
     }
 
+    @DisplayName("조인 쿼리를 생성할 수 있는지 여부를 알 수 있다.")
+    @Test
+    void isOneToMany() {
+        assertThat(meta.isOneToMany())
+                .isTrue();
+    }
+
     @DisplayName("조인되는 자식의 클래스 정보를 Meta 객체 형태로 가공할 수 있다.")
     @Test
     void getChildMeta() {
@@ -91,7 +105,9 @@ class EntityMetaTest {
                 () -> assertThat(childMeta.getPkName())
                         .isEqualTo("id"),
                 () -> assertThat(childMeta.getFkName())
-                        .isEqualTo(null)
+                        .isEqualTo(null),
+                () -> assertThat(childMeta.isOneToMany())
+                        .isFalse()
         );
     }
 }

--- a/src/test/java/persistence/entity/EntityMetaTest.java
+++ b/src/test/java/persistence/entity/EntityMetaTest.java
@@ -1,5 +1,6 @@
 package persistence.entity;
 
+import domain.LazyOrder;
 import domain.Order;
 import domain.OrderItem;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,8 +70,15 @@ class EntityMetaTest {
 
     @DisplayName("조인 쿼리를 생성할 수 있는지 여부를 알 수 있다.")
     @Test
-    void isOneToMany() {
+    void isEagerOneToMany() {
         assertThat(meta.isEagerOneToMany())
+                .isTrue();
+    }
+
+    @DisplayName("OneToMany 가 Lazy 한지 여부를 알 수 있다.")
+    @Test
+    void isLazyOneToMany() {
+        assertThat(new EntityMeta(LazyOrder.class).isLazyOneToMany())
                 .isTrue();
     }
 

--- a/src/test/java/persistence/sql/ddl/h2/H2CreateQueryTest.java
+++ b/src/test/java/persistence/sql/ddl/h2/H2CreateQueryTest.java
@@ -1,5 +1,7 @@
 package persistence.sql.ddl.h2;
 
+import domain.Order;
+import domain.OrderItem;
 import domain.Person;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,7 +13,7 @@ class H2CreateQueryTest {
 
     @Test
     @DisplayName("Person Entity 를 위한 CREATE 쿼리를 생성한다.")
-    void createQuery() {
+    void createPerson() {
         String expected = "CREATE TABLE users ("
                 + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
                 + "nick_name VARCHAR(255), "
@@ -20,6 +22,32 @@ class H2CreateQueryTest {
                 + ")";
         assertThat(
                 H2CreateQuery.build(Person.class)
+        ).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Order Entity 를 위한 CREATE 쿼리를 생성한다.")
+    void createOrder() {
+        String expected = "CREATE TABLE orders ("
+                + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
+                + "order_number VARCHAR(255)"
+                + ")";
+        assertThat(
+                H2CreateQuery.build(Order.class)
+        ).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("OrderItem Entity 를 위한 CREATE 쿼리를 생성한다.")
+    void createOrderItem() {
+        String expected = "CREATE TABLE order_items ("
+                + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
+                + "product VARCHAR(255), "
+                + "quantity INTEGER, "
+                + "order_id BIGINT"
+                + ")";
+        assertThat(
+                H2CreateQuery.build(OrderItem.class)
         ).isEqualTo(expected);
     }
 }

--- a/src/test/java/persistence/sql/ddl/h2/H2DdlBuilderTest.java
+++ b/src/test/java/persistence/sql/ddl/h2/H2DdlBuilderTest.java
@@ -1,5 +1,7 @@
 package persistence.sql.ddl.h2;
 
+import domain.Order;
+import domain.OrderItem;
 import domain.Person;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,7 +20,7 @@ class H2DdlBuilderTest {
 
     @Test
     @DisplayName("Person Entity 를 위한 CREATE 쿼리를 생성한다.")
-    void createQuery() {
+    void createPerson() {
         String expected = "CREATE TABLE users ("
                 + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
                 + "nick_name VARCHAR(255), "
@@ -31,11 +33,55 @@ class H2DdlBuilderTest {
     }
 
     @Test
+    @DisplayName("Order Entity 를 위한 CREATE 쿼리를 생성한다.")
+    void createOrder() {
+        String expected = "CREATE TABLE orders ("
+                + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
+                + "order_number VARCHAR(255)"
+                + ")";
+        assertThat(
+                ddl.getCreateQuery(Order.class)
+        ).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("OrderItem Entity 를 위한 CREATE 쿼리를 생성한다.")
+    void createOrderItem() {
+        String expected = "CREATE TABLE order_items ("
+                + "id BIGINT AUTO_INCREMENT PRIMARY KEY, "
+                + "product VARCHAR(255), "
+                + "quantity INTEGER, "
+                + "order_id BIGINT"
+                + ")";
+        assertThat(
+                ddl.getCreateQuery(OrderItem.class)
+        ).isEqualTo(expected);
+    }
+
+    @Test
     @DisplayName("Person Entity 를 위한 drop 쿼리를 생성한다.")
-    void dropQuery() {
+    void dropPerson() {
         final String expected = "DROP TABLE IF EXISTS users";
         assertThat(
                 ddl.getDropQuery(Person.class)
+        ).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Order Entity 를 위한 drop 쿼리를 생성한다.")
+    void dropOrder() {
+        final String expected = "DROP TABLE IF EXISTS orders";
+        assertThat(
+                ddl.getDropQuery(Order.class)
+        ).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("OrderItem Entity 를 위한 drop 쿼리를 생성한다.")
+    void dropOrderItem() {
+        final String expected = "DROP TABLE IF EXISTS order_items";
+        assertThat(
+                ddl.getDropQuery(OrderItem.class)
         ).isEqualTo(expected);
     }
 }

--- a/src/test/java/persistence/sql/ddl/h2/H2DropQueryTest.java
+++ b/src/test/java/persistence/sql/ddl/h2/H2DropQueryTest.java
@@ -1,5 +1,7 @@
 package persistence.sql.ddl.h2;
 
+import domain.Order;
+import domain.OrderItem;
 import domain.Person;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -7,13 +9,30 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class H2DropQueryTest {
-
     @Test
     @DisplayName("Person Entity 를 위한 drop 쿼리를 생성한다.")
-    void dropQuery() {
+    void dropPerson() {
         final String expected = "DROP TABLE IF EXISTS users";
         assertThat(
                 H2DropQuery.build(Person.class)
+        ).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Order Entity 를 위한 drop 쿼리를 생성한다.")
+    void dropOrder() {
+        final String expected = "DROP TABLE IF EXISTS orders";
+        assertThat(
+                H2DropQuery.build(Order.class)
+        ).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("OrderItem Entity 를 위한 drop 쿼리를 생성한다.")
+    void dropOrderItem() {
+        final String expected = "DROP TABLE IF EXISTS order_items";
+        assertThat(
+                H2DropQuery.build(OrderItem.class)
         ).isEqualTo(expected);
     }
 }

--- a/src/test/java/persistence/sql/dml/h2/H2DmlBuilderTest.java
+++ b/src/test/java/persistence/sql/dml/h2/H2DmlBuilderTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Test;
 import persistence.entity.EntityMeta;
 import persistence.sql.dml.DmlBuilder;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class H2DmlBuilderTest {
@@ -53,6 +56,17 @@ class H2DmlBuilderTest {
         assertThat(
                 dml.getFindAllQuery(Person.class)
         ).isEqualTo(expected);
+    }
+
+    @DisplayName("Where 조건문을 생성할 수 있다.")
+    @Test
+    void where() {
+        String expected = " WHERE id = 1, name = 'ghojeong'";
+        Map<String, Object> condition = new LinkedHashMap<>();
+        condition.put("id", 1);
+        condition.put("name", "ghojeong");
+        assertThat(dml.getWhereQuery(condition))
+                .isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/persistence/sql/dml/h2/H2DmlBuilderTest.java
+++ b/src/test/java/persistence/sql/dml/h2/H2DmlBuilderTest.java
@@ -1,10 +1,12 @@
 package persistence.sql.dml.h2;
 
+import domain.Order;
 import domain.Person;
 import domain.PersonFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import persistence.entity.EntityMeta;
 import persistence.sql.dml.DmlBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,6 +27,20 @@ class H2DmlBuilderTest {
                 + " VALUES ('고정완', 30, 'ghojeong@email.com')";
         assertThat(
                 dml.getInsertQuery(PersonFixture.createPerson())
+        ).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Order Entity 를 위한 join 쿼리를 생성한다.")
+    void eagerJoinQuery() {
+        String expected = "SELECT"
+                + " t1.id, t1.order_number,"
+                + " t2.id, t2.product, t2.quantity, t2.order_id"
+                + " FROM orders AS t1"
+                + " INNER JOIN order_items AS t2"
+                + " ON t1.id = t2.order_id";
+        assertThat(
+                dml.getEagerJoinQuery(new EntityMeta(Order.class))
         ).isEqualTo(expected);
     }
 

--- a/src/test/java/persistence/sql/dml/h2/H2DmlBuilderTest.java
+++ b/src/test/java/persistence/sql/dml/h2/H2DmlBuilderTest.java
@@ -34,8 +34,8 @@ class H2DmlBuilderTest {
     @DisplayName("Order Entity 를 위한 join 쿼리를 생성한다.")
     void eagerJoinQuery() {
         String expected = "SELECT"
-                + " t1.id, t1.order_number,"
-                + " t2.id, t2.product, t2.quantity, t2.order_id"
+                + " t1.id AS t1_id, t1.order_number AS t1_order_number,"
+                + " t2.id AS t2_id, t2.product AS t2_product, t2.quantity AS t2_quantity, t2.order_id AS t2_order_id"
                 + " FROM orders AS t1"
                 + " INNER JOIN order_items AS t2"
                 + " ON t1.id = t2.order_id";

--- a/src/test/java/persistence/sql/dml/h2/H2EagerJoinQueryTest.java
+++ b/src/test/java/persistence/sql/dml/h2/H2EagerJoinQueryTest.java
@@ -1,0 +1,25 @@
+package persistence.sql.dml.h2;
+
+import domain.Order;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import persistence.entity.EntityMeta;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class H2EagerJoinQueryTest {
+
+    @DisplayName("Order 의 OrderItem 에 대한 fetch join 쿼리를 생성한다.")
+    @Test
+    void build() {
+        String expected = "SELECT"
+                + " t1.id, t1.order_number,"
+                + " t2.id, t2.product, t2.quantity, t2.order_id"
+                + " FROM orders AS t1"
+                + " INNER JOIN order_items AS t2"
+                + " ON t1.id = t2.order_id";
+        assertThat(
+                H2EagerJoinQuery.build(new EntityMeta(Order.class))
+        ).isEqualTo(expected);
+    }
+}

--- a/src/test/java/persistence/sql/dml/h2/H2EagerJoinQueryTest.java
+++ b/src/test/java/persistence/sql/dml/h2/H2EagerJoinQueryTest.java
@@ -13,8 +13,8 @@ class H2EagerJoinQueryTest {
     @Test
     void build() {
         String expected = "SELECT"
-                + " t1.id, t1.order_number,"
-                + " t2.id, t2.product, t2.quantity, t2.order_id"
+                + " t1.id AS t1_id, t1.order_number AS t1_order_number,"
+                + " t2.id AS t2_id, t2.product AS t2_product, t2.quantity AS t2_quantity, t2.order_id AS t2_order_id"
                 + " FROM orders AS t1"
                 + " INNER JOIN order_items AS t2"
                 + " ON t1.id = t2.order_id";

--- a/src/test/java/persistence/sql/dml/h2/H2WhereQueryTest.java
+++ b/src/test/java/persistence/sql/dml/h2/H2WhereQueryTest.java
@@ -1,0 +1,23 @@
+package persistence.sql.dml.h2;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class H2WhereQueryTest {
+
+    @DisplayName("Where 조건문을 생성할 수 있다.")
+    @Test
+    void build() {
+        String expected = " WHERE id = 1, name = 'ghojeong'";
+        Map<String, Object> condition = new LinkedHashMap<>();
+        condition.put("id", 1);
+        condition.put("name", "ghojeong");
+        assertThat(H2WhereQuery.build(condition))
+                .isEqualTo(expected);
+    }
+}

--- a/src/test/java/proxy/CallbackProxyTest.java
+++ b/src/test/java/proxy/CallbackProxyTest.java
@@ -1,0 +1,30 @@
+package proxy;
+
+import net.sf.cglib.proxy.Enhancer;
+import net.sf.cglib.proxy.MethodInterceptor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class CallbackProxyTest {
+    @Test
+    void toUppercase() {
+        Enhancer enhancer = new Enhancer();
+        enhancer.setSuperclass(HelloTarget.class);
+        enhancer.setCallback((MethodInterceptor) (obj, method, args, proxy) -> {
+            Object result = proxy.invokeSuper(obj, args);
+            return (result instanceof String) && method.getName().startsWith("say")
+                    ? ((String) result).toUpperCase()
+                    : result;
+        });
+        Hello proxiedHello = (Hello) enhancer.create();
+        assertAll(
+                () -> assertThat(proxiedHello.sayHello("javajigi")).isEqualTo("HELLO JAVAJIGI"),
+                () -> assertThat(proxiedHello.sayHi("javajigi")).isEqualTo("HI JAVAJIGI"),
+                () -> assertThat(proxiedHello.sayThankYou("javajigi")).isEqualTo("THANK YOU JAVAJIGI"),
+                () -> assertThat(proxiedHello.pingPong("javajigi")).isEqualTo("Pong javajigi")
+        );
+
+    }
+}

--- a/src/test/java/proxy/InterfaceProxyTest.java
+++ b/src/test/java/proxy/InterfaceProxyTest.java
@@ -1,0 +1,30 @@
+package proxy;
+
+import net.sf.cglib.proxy.Proxy;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class InterfaceProxyTest {
+    @Test
+    void toUppercase() {
+        Hello hello = new HelloTarget();
+        Hello proxiedHello = (Hello) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class[]{Hello.class},
+                (proxy, method, args) -> {
+                    Object result = method.invoke(hello, args);
+                    return (result instanceof String) && method.getName().startsWith("say")
+                            ? ((String) result).toUpperCase()
+                            : result;
+                }
+        );
+        assertAll(
+                () -> assertThat(proxiedHello.sayHello("javajigi")).isEqualTo("HELLO JAVAJIGI"),
+                () -> assertThat(proxiedHello.sayHi("javajigi")).isEqualTo("HI JAVAJIGI"),
+                () -> assertThat(proxiedHello.sayThankYou("javajigi")).isEqualTo("THANK YOU JAVAJIGI"),
+                () -> assertThat(proxiedHello.pingPong("javajigi")).isEqualTo("Pong javajigi")
+        );
+    }
+}

--- a/src/test/java/proxy/SimpleProxyTest.java
+++ b/src/test/java/proxy/SimpleProxyTest.java
@@ -17,12 +17,9 @@ class SimpleProxyTest {
     void executeProxy() {
         Enhancer enhancer = new Enhancer();
         enhancer.setSuperclass(Person.class);
-        enhancer.setCallback(new LazyLoader() {
-            @Override
-            public Object loadObject() throws Exception {
-                System.out.println("프록시가 실행됨");
-                return PersonFixture.createPerson();
-            }
+        enhancer.setCallback((LazyLoader) () -> {
+            System.out.println("프록시가 실행됨");
+            return PersonFixture.createPerson();
         });
 
         Person person = (Person) enhancer.create();


### PR DESCRIPTION
Order 와 같은 Entity 의 정보를 EntityMeta 라는 메타데이터로 가공해서,
parent 와 child 엔티티의 메타데이터를 재귀적으로 가져올 수 있도록 했습니다.

EntityMeta 를 기반으로 H2EagerJoinQuery 에서 Join 쿼리를 생성하고,
OneToManyEntityLoader 에서 쿼리 결과를 Object 로 매핑을 할 수 있도록 하였습니다.