### PR TITLE
Step1 OneToMany (FetchType.EAGER) + Step 2 LazyLoading by Proxy 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
 # jpa-association
+
+
+# 1단계
+
+
+
+## 1. 요구사항 JOIN QUERY 만들기 --> 이거는 jpa로 query 일단 뽑아내기 join -> fetch join으로 나타내기
+예시:
+
+```sql
+SELECT orders.id, orders.orderNumber, orderItems.id, orderItems.product, orderItems.quantity
+FROM orders
+JOIN orderItems on orders.id = orderItems.order_id
+WHERE orders.id IN [1,2,3]
+```
+
+```sql
+SELECT [<TABLE>.<COLUMNNAME> ...] -- COLUMN CLAUSE
+FROM [<TABLE>] -- FROM
+JOIN [<TABLE TO JOIN>] -- JOIN TABLE 
+ON [<TABLE>.<COLUMN> = <TABLE TO JOIN>.<COLUMN FKEY>] -- JOIN ON CLAUSE
+WHERE <TABLE>.<COLUMNNAME> IN [<VALUES>] -- WHERE CLAUSE
+```
+
+1. Column clause -> table 이름 앞에 붙이기
+2. FROM -> table 이름
+3. JOIN TABLE -> table to join 이름
+4. JOIN ON CLAUSE ON Table의 id 와 TABLE TO JOIN 의 fk
+5. WHERE CLAUSE  orders.id IN
+
+인수 (table, list<column> columns, whereclause)
+인수 2(tabletojoin, list<column> columns, fkey)
+
+
+구현 요소
+1. JoinQueryBuilder -> JoinQuery(불변) 생성하기
+    - Builder 객체들이 각각 select절을 만들고 where 절을 만들게 되는데 Clause 생성객체가 분리되어야한다.
+    - 하지만 수정범위가 크니깐 JoinQuery를 미래에 리팩토링이 편하게 만들어 두자.
+2. 아쉬운점
+   추상화 요소들 (SELECT CLAUSE, WHERE CLAUSE, JOIN CLAUSE) 들에 대해서 너무 늦게 파악했다.
+
+검증 요소
+1. JOIN QUERY 생성 검증
+
+## 2. Join Query 만들어서 Entity 화하기
+
+select 이후에 eager이면 join fetch 진행 아니면 lazy
+
+1. Loader에서 가져오는 로직 분기 필요 -> isRelation 이면 subEntity 필요해서 fetch join --> 얘도 분리가 필요하다고 강의에서 들은것같은데
+    - 여기도 추상화가 필요하다
+    - CollectionElementLoader(column, entity) -> 피드백 참고
+        - rowmapper 따로 분기
+        - eager
+        - lazy
+        - join 문 2번이면 recursive인가?
+
+2. EntityClass에 IsRelation을 만들거나 RelationalEntity를 만들어야되나 생각중이다.
+    - Relation interface 로 emptyClass(null pattern) 와 RelationColumn(fetch type, collection type) 구현 필요
+    - loader에서 사용해야 될 relation, joincolumn 정보 필요
+    - IsRelation로 만들자
+    - mapping은 조금더 봐야할듯
+3. Rowmapper를 사용할때 여기서도 isRelation 값이 따로 필요한데 흠... oneToManyRowMapper를 따로 해야할지 생각필요하다
+    - 이거 가져오는 로직이 있어서 다행이다. -> 피드백 참고
+    - 얘도 따로 분기되야할듯 -> collection type 가져오는 부분이 단일 rowmapper 와 다르다.
+      검증 요소
+
+1. Loader에서 CollectionEntity 로드 확인
+2. EntityClass에서 Relationship 관련 컬럼확인
+3. RowMapper에서 Collection Entity 만드는것을 확인
+~
+0 단계 리뷰사항
+
+- 테스트 멱등성을 위해 테스트마다 다른 pk 삽입
+- create table시에 있다면 생성하지 않는 방향으로 table 생성
+- 너무 작은 변경에도 쉽게 허물어지는데 mapping 로직 확인 필요하다.

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     implementation 'com.h2database:h2:2.1.214'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
     testImplementation 'org.assertj:assertj-core:3.24.2'
+    implementation 'cglib:cglib:3.3.0'
+
 }
 compileJava.options.encoding = 'UTF-8'
 tasks.withType(JavaCompile){

--- a/src/main/java/domain/Order.java
+++ b/src/main/java/domain/Order.java
@@ -1,0 +1,26 @@
+package domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.List;
+
+@Entity
+@Table(name = "orders")
+public class Order {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String orderNumber;
+
+  @OneToMany(fetch = FetchType.EAGER)
+  @JoinColumn(name = "order_id")
+  private List<OrderItem> orderItems;
+}

--- a/src/main/java/domain/OrderItem.java
+++ b/src/main/java/domain/OrderItem.java
@@ -1,0 +1,20 @@
+package domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "order_items")
+public class OrderItem {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String product;
+
+  private Integer quantity;
+}

--- a/src/main/java/jdbc/CollectionRowMapper.java
+++ b/src/main/java/jdbc/CollectionRowMapper.java
@@ -24,7 +24,7 @@ public class CollectionRowMapper<T, V> implements RowMapper<T> {
 
     for (MetaDataColumn metaDataColumn : metaDataColumns.getMetaDataColumns()) {
       String dbName = metaDataColumn.getDBColumnName();
-      String columnName = String.join(DELIMITER, dbName,
+      String columnName = String.join(DELIMITER, metaEntity.getTableName(),
           metaDataColumn.getDBColumnName());
       metaDataColumn.setFieldValue(entityInstance, resultSet.getObject(columnName));
     }
@@ -39,7 +39,7 @@ public class CollectionRowMapper<T, V> implements RowMapper<T> {
 
       for (MetaDataColumn metaDataColumn : elementDataColumns.getMetaDataColumns()) {
         String dbName = metaDataColumn.getDBColumnName();
-        String columnName = String.join(DELIMITER, dbName,
+        String columnName = String.join(DELIMITER, elementEntity.getTableName(),
             metaDataColumn.getDBColumnName());
         metaDataColumn.setFieldValue(elementInstance, resultSet.getObject(columnName));
       }

--- a/src/main/java/jdbc/CollectionRowMapper.java
+++ b/src/main/java/jdbc/CollectionRowMapper.java
@@ -1,0 +1,54 @@
+package jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import persistence.meta.MetaDataColumn;
+import persistence.meta.MetaDataColumns;
+import persistence.meta.MetaEntity;
+import persistence.meta.Relation;
+
+public class CollectionRowMapper<T, V> implements RowMapper<T> {
+  public static String DELIMITER = ".";
+  private final MetaEntity<T> metaEntity;
+  private final MetaEntity<V> elementEntity;
+  public CollectionRowMapper(MetaEntity<T> metaEntity, MetaEntity<V> elementEntity) {
+    this.metaEntity = metaEntity;
+    this.elementEntity = elementEntity;
+  }
+  @Override
+  public T mapRow(ResultSet resultSet) throws SQLException {
+    T entityInstance = metaEntity.createInstance();
+    MetaDataColumns metaDataColumns = metaEntity.getMetaDataColumns();
+
+    for (MetaDataColumn metaDataColumn : metaDataColumns.getMetaDataColumns()) {
+      String dbName = metaDataColumn.getDBColumnName();
+      String columnName = String.join(DELIMITER, dbName,
+          metaDataColumn.getDBColumnName());
+      metaDataColumn.setFieldValue(entityInstance, resultSet.getObject(columnName));
+    }
+
+    Relation relation = metaDataColumns.getRelation();
+    MetaDataColumn relationColumn = metaEntity.getMetaDataColumns().getColumnByFieldName(relation.getFieldName());
+    List<V> elements = new ArrayList<>();
+
+    do {
+      V elementInstance = elementEntity.createInstance();
+      MetaDataColumns elementDataColumns = elementEntity.getMetaDataColumns();
+
+      for (MetaDataColumn metaDataColumn : elementDataColumns.getMetaDataColumns()) {
+        String dbName = metaDataColumn.getDBColumnName();
+        String columnName = String.join(DELIMITER, dbName,
+            metaDataColumn.getDBColumnName());
+        metaDataColumn.setFieldValue(elementInstance, resultSet.getObject(columnName));
+      }
+      elements.add(elementInstance);
+    }
+    while (resultSet.next());
+
+    relationColumn.setFieldValue(entityInstance, elements);
+
+    return entityInstance;
+  }
+}

--- a/src/main/java/jdbc/JdbcRowMapper.java
+++ b/src/main/java/jdbc/JdbcRowMapper.java
@@ -14,7 +14,6 @@ public class JdbcRowMapper<T> implements RowMapper<T> {
   }
   @Override
   public T mapRow(ResultSet resultSet) throws SQLException {
-    resultSet.next();
 
     T entityInstance = metaEntity.createInstance();
     MetaDataColumns metaDataColumns = metaEntity.getMetaDataColumns();

--- a/src/main/java/jdbc/JdbcTemplate.java
+++ b/src/main/java/jdbc/JdbcTemplate.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class JdbcTemplate {
+
+    public static final int COLUMN_INDEX = 1;
     private final Connection connection;
 
     public JdbcTemplate(final Connection connection) {
@@ -21,20 +23,26 @@ public class JdbcTemplate {
             throw new RuntimeException(e);
         }
     }
+
     public Long executeWithGeneratedKey(final String sql) {
-        try (final PreparedStatement statement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+        try (final PreparedStatement statement = connection.prepareStatement(sql,
+            Statement.RETURN_GENERATED_KEYS)) {
             statement.execute();
             ResultSet resultSet = statement.getGeneratedKeys();
             resultSet.next();
 
-            return resultSet.getLong(1);
+            return resultSet.getLong(COLUMN_INDEX);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
+
     public <T> T queryForObject(final String sql, final RowMapper<T> rowMapper) {
         try (final ResultSet resultSet = connection.prepareStatement(sql).executeQuery()) {
-            return rowMapper.mapRow(resultSet);
+            if (resultSet.next()) {
+                return rowMapper.mapRow(resultSet);
+            }
+            return null;
         } catch (Exception e) {
             throw new RuntimeException("해당 객체는 존재 하지 않습니다.", e);
         }

--- a/src/main/java/persistence/dialect/Dialect.java
+++ b/src/main/java/persistence/dialect/Dialect.java
@@ -1,6 +1,7 @@
 package persistence.dialect;
 
 import java.lang.reflect.Field;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/persistence/dialect/h2/H2Dialect.java
+++ b/src/main/java/persistence/dialect/h2/H2Dialect.java
@@ -2,6 +2,7 @@ package persistence.dialect.h2;
 
 import java.lang.reflect.Field;
 import java.sql.Types;
+import java.util.Collection;
 import org.h2.value.DataType;
 import org.h2.value.Value;
 import persistence.dialect.Dialect;
@@ -15,6 +16,9 @@ public class H2Dialect extends Dialect {
   }
 
   public String convertToColumn(Field field) {
+    if (Collection.class.isAssignableFrom(field.getType())) {
+      return field.getType().getName();
+    }
     Integer type = getJavaSqlType(field);
     return Value.getTypeName(DataType.convertSQLTypeToValueType(type));
   }

--- a/src/main/java/persistence/entity/CollectionElementLoader.java
+++ b/src/main/java/persistence/entity/CollectionElementLoader.java
@@ -64,7 +64,7 @@ public class CollectionElementLoader<T> implements RelationLoader<T>{
     }
 
     String joinQuery = new JoinQueryBuilder()
-        .select(metaEntity.getTableName(), metaEntity.getEntityColumnsWithId(), elementEntity.getEntityColumnsWithId())
+        .select(metaEntity.getTableName(),elementEntity.getTableName(), metaEntity.getEntityColumnsWithId(), elementEntity.getEntityColumnsWithId())
         .join(List.of(elementEntity.getTableName()))
         .on(List.of(relation.getDbName()))
         .where(metaEntity.getPrimaryKeyColumn().getDBColumnName(), List.of(String.valueOf(id)))
@@ -92,7 +92,7 @@ public class CollectionElementLoader<T> implements RelationLoader<T>{
     }
 
     String joinQuery = new JoinQueryBuilder()
-        .select(metaEntity.getTableName(), metaEntity.getEntityColumnsWithId(), elementEntity.getEntityColumnsWithId())
+        .select(metaEntity.getTableName(),elementEntity.getTableName(), metaEntity.getEntityColumnsWithId(), elementEntity.getEntityColumnsWithId())
         .join(List.of(elementEntity.getTableName()))
         .on(List.of(relation.getDbName()))
         .where(metaEntity.getPrimaryKeyColumn().getDBColumnName(), List.of(String.valueOf(ids)))

--- a/src/main/java/persistence/entity/CollectionElementLoader.java
+++ b/src/main/java/persistence/entity/CollectionElementLoader.java
@@ -1,0 +1,107 @@
+package persistence.entity;
+
+import jakarta.persistence.FetchType;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Optional;
+import jdbc.CollectionRowMapper;
+import jdbc.JdbcRowMapper;
+import jdbc.JdbcTemplate;
+import jdbc.RowMapper;
+import persistence.meta.MetaDataColumn;
+import persistence.meta.MetaDataColumns;
+import persistence.meta.MetaEntity;
+import persistence.meta.Relation;
+import persistence.sql.dml.builder.JoinQueryBuilder;
+import persistence.sql.dml.builder.SelectQueryBuilder;
+
+public class CollectionElementLoader<T> implements RelationLoader<T>{
+  private final JdbcTemplate jdbcTemplate;
+  private final SelectQueryBuilder selectQueryBuilder = new SelectQueryBuilder();
+  private final MetaEntity<T> metaEntity;
+  private final RowMapper<T> rowMapper;
+  private final MetaEntity<?> elementEntity;
+  private final RowMapper<T> elementRowMapper;
+  private final Relation relation;
+
+  private CollectionElementLoader(Connection connection, MetaEntity<T> metaEntity,
+      MetaEntity<?> elementEntity, Relation relation) {
+    this.jdbcTemplate = new JdbcTemplate(connection);
+    this.metaEntity = metaEntity;
+    this.elementEntity = elementEntity;
+    this.rowMapper = new JdbcRowMapper<>(metaEntity);
+    this.elementRowMapper = new CollectionRowMapper<>(metaEntity, elementEntity);
+    this.relation = relation;
+  }
+
+  public static CollectionElementLoader<?> of(Class<?> clazz, Connection connection){
+
+    MetaEntity<?> entity = MetaEntity.of(clazz);
+    MetaDataColumns columns = entity.getMetaDataColumns();
+    Relation relation = columns.getRelation();
+
+    MetaEntity<?> elementEntity = relation.getMetaEntity();
+
+
+    return new CollectionElementLoader<>(connection, entity, elementEntity, relation);
+  }
+
+  @Override
+  public Optional<T> load(Long id) {
+
+    MetaDataColumn keyColumn = metaEntity.getPrimaryKeyColumn();
+    String targetColumn = keyColumn.getDBColumnName();
+
+    String query = selectQueryBuilder.createSelectByFieldQuery(metaEntity.getColumnClauseWithId(),
+        metaEntity.getTableName(), targetColumn, id);
+
+    T entity = jdbcTemplate.queryForObject(query, rowMapper);
+
+    if(relation.getFetchType() == FetchType.LAZY){
+      MetaDataColumn relationColumn = metaEntity.getMetaDataColumns().getColumnByFieldName(relation.getFieldName());
+//      relationColumn.setFieldValue(entity, elements); proxy 예정
+      return Optional.ofNullable(entity);
+    }
+
+    String joinQuery = new JoinQueryBuilder()
+        .select(metaEntity.getTableName(), metaEntity.getEntityColumnsWithId(), elementEntity.getEntityColumnsWithId())
+        .join(List.of(elementEntity.getTableName()))
+        .on(List.of(relation.getDbName()))
+        .where(metaEntity.getPrimaryKeyColumn().getDBColumnName(), List.of(String.valueOf(id)))
+        .build().createJoinQuery();
+
+    return Optional.ofNullable(jdbcTemplate.queryForObject(joinQuery, elementRowMapper));
+
+  }
+
+  @Override
+  public List<T> loadByIds(List<Long> ids) {
+
+    MetaDataColumn keyColumn = metaEntity.getPrimaryKeyColumn();
+    String targetColumn = keyColumn.getDBColumnName();
+
+    String query = selectQueryBuilder.createSelectByFieldQuery(metaEntity.getColumnClauseWithId(),
+        metaEntity.getTableName(), targetColumn, ids);
+
+    List<T> entities = jdbcTemplate.query(query, rowMapper);
+
+    if(relation.getFetchType() == FetchType.LAZY){
+      MetaDataColumn relationColumn = metaEntity.getMetaDataColumns().getColumnByFieldName(relation.getFieldName());
+//      relationColumn.setFieldValue(entity, elements); proxy 예정
+      return entities;
+    }
+
+    String joinQuery = new JoinQueryBuilder()
+        .select(metaEntity.getTableName(), metaEntity.getEntityColumnsWithId(), elementEntity.getEntityColumnsWithId())
+        .join(List.of(elementEntity.getTableName()))
+        .on(List.of(relation.getDbName()))
+        .where(metaEntity.getPrimaryKeyColumn().getDBColumnName(), List.of(String.valueOf(ids)))
+        .build().createJoinQuery();
+
+    List<T> entitiesWithCollection = jdbcTemplate.query(joinQuery, elementRowMapper);
+
+    return entitiesWithCollection;
+  }
+
+
+}

--- a/src/main/java/persistence/entity/CollectionElementLoader.java
+++ b/src/main/java/persistence/entity/CollectionElementLoader.java
@@ -4,6 +4,7 @@ import jakarta.persistence.FetchType;
 import java.sql.Connection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import jdbc.CollectionRowMapper;
 import jdbc.JdbcRowMapper;
 import jdbc.JdbcTemplate;
@@ -80,8 +81,10 @@ public class CollectionElementLoader<T> implements RelationLoader<T>{
     MetaDataColumn keyColumn = metaEntity.getPrimaryKeyColumn();
     String targetColumn = keyColumn.getDBColumnName();
 
-    String query = selectQueryBuilder.createSelectByFieldQuery(metaEntity.getColumnClauseWithId(),
-        metaEntity.getTableName(), targetColumn, ids);
+    List<String> idValues = ids.stream().map(Object::toString).collect(Collectors.toList());
+
+    String query = selectQueryBuilder.createSelectByFieldsQuery(metaEntity.getColumnClauseWithId(),
+        metaEntity.getTableName(), targetColumn, idValues);
 
     List<T> entities = jdbcTemplate.query(query, rowMapper);
 
@@ -95,7 +98,7 @@ public class CollectionElementLoader<T> implements RelationLoader<T>{
         .select(metaEntity.getTableName(),elementEntity.getTableName(), metaEntity.getEntityColumnsWithId(), elementEntity.getEntityColumnsWithId())
         .join(List.of(elementEntity.getTableName()))
         .on(List.of(relation.getDbName()))
-        .where(metaEntity.getPrimaryKeyColumn().getDBColumnName(), List.of(String.valueOf(ids)))
+        .where(metaEntity.getPrimaryKeyColumn().getDBColumnName(), idValues)
         .build().createJoinQuery();
 
     List<T> entitiesWithCollection = jdbcTemplate.query(joinQuery, elementRowMapper);

--- a/src/main/java/persistence/entity/EmptyCollectionLoader.java
+++ b/src/main/java/persistence/entity/EmptyCollectionLoader.java
@@ -1,0 +1,18 @@
+package persistence.entity;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class EmptyCollectionLoader<T> implements RelationLoader<T>{
+
+  @Override
+  public Optional<T> load(Long id) {
+    return Optional.empty();
+  }
+
+  @Override
+  public List<T> loadByIds(List<Long> ids) {
+    return Collections.emptyList();
+  }
+}

--- a/src/main/java/persistence/entity/EntityLoader.java
+++ b/src/main/java/persistence/entity/EntityLoader.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 public interface EntityLoader<T> {
   <T> Optional<T> load(Long id);
+
   List<T> findAll();
 
   List<T> loadByIds(List<Long> ids);

--- a/src/main/java/persistence/entity/JdbcEntityLoader.java
+++ b/src/main/java/persistence/entity/JdbcEntityLoader.java
@@ -31,12 +31,7 @@ public class JdbcEntityLoader<T> implements EntityLoader<T> {
     String query = selectQueryBuilder.createSelectByFieldQuery(metaEntity.getColumnClauseWithId(),
         metaEntity.getTableName(), targetColumn, id);
 
-    try {
-      return Optional.ofNullable(jdbcTemplate.queryForObject(query, jdbcRowMapper));
-    } catch (RuntimeException e) {
-      return Optional.empty();
-    }
-
+    return Optional.ofNullable(jdbcTemplate.queryForObject(query, jdbcRowMapper));
   }
 
   @Override

--- a/src/main/java/persistence/entity/JdbcEntityManager.java
+++ b/src/main/java/persistence/entity/JdbcEntityManager.java
@@ -49,9 +49,10 @@ public class JdbcEntityManager implements EntityManager {
     entityEntry.putEntityEntryStatus(entity, EntityStatus.SAVING);
     Long assignedId = persister.getEntityId(entity).orElse(-1L);
 
-    if (persister.entityExists(entity) &&
-        !persistenceContext.isSameWithSnapshot(assignedId, entity)) {
-
+    if (persister.entityExists(entity)){
+      if(persistenceContext.isSameWithSnapshot(assignedId, entity)) {
+        return;
+      }
       persister.update(entity);
       putPersistenceContext(assignedId, entity);
       return;

--- a/src/main/java/persistence/entity/JdbcEntityPersister.java
+++ b/src/main/java/persistence/entity/JdbcEntityPersister.java
@@ -15,11 +15,13 @@ public class JdbcEntityPersister<T> implements EntityPersister<T> {
   private final JdbcTemplate jdbcTemplate;
   private final MetaEntity<T> metaEntity;
   private final EntityLoader<T> entityLoader;
+  private final RelationLoader relationLoader;
   private final DmlQueryBuilder dmlQueryBuilder = new DmlQueryBuilder();
 
   public JdbcEntityPersister(Class<T> clazz, Connection connection) {
     this.jdbcTemplate = new JdbcTemplate(connection);
     this.metaEntity = MetaEntity.of(clazz);
+    this.relationLoader = metaEntity.hasRelation() ? new EmptyCollectionLoader() : CollectionElementLoader.of(clazz, connection);
     this.entityLoader = new JdbcEntityLoader<T>(clazz, connection);
   }
 
@@ -101,10 +103,16 @@ public class JdbcEntityPersister<T> implements EntityPersister<T> {
   }
 
   public Optional<T> load(Long id) {
+    if(metaEntity.hasRelation()){
+      return relationLoader.load(id);
+    }
     return entityLoader.load(id);
   }
 
   public List<T> loadAll(List<Long> ids) {
+    if(metaEntity.hasRelation()){
+      return relationLoader.loadByIds(ids);
+    }
     return entityLoader.loadByIds(ids);
   }
 }

--- a/src/main/java/persistence/entity/JdbcPersistenceContext.java
+++ b/src/main/java/persistence/entity/JdbcPersistenceContext.java
@@ -11,7 +11,6 @@ public class JdbcPersistenceContext implements PersistenceContext {
 
   private final Map<EntityKey, Object> entityCache = new ConcurrentHashMap<>();
   private final Map<EntityKey, Object> entitySnapshot = new ConcurrentHashMap<>();
-  private final EntityEntry entityEntry = new JdbcEntityEntry();
   @Override
   public Optional<Object> getEntity(Long id, Class<?> clazz) {
     return Optional.ofNullable(entityCache.get(new EntityKey(clazz, id)));

--- a/src/main/java/persistence/entity/RelationLoader.java
+++ b/src/main/java/persistence/entity/RelationLoader.java
@@ -1,0 +1,11 @@
+package persistence.entity;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RelationLoader<T> {
+
+  <T> Optional<T> load(Long id);
+
+  List<T> loadByIds(List<Long> ids);
+}

--- a/src/main/java/persistence/meta/MetaDataColumn.java
+++ b/src/main/java/persistence/meta/MetaDataColumn.java
@@ -15,13 +15,16 @@ public class MetaDataColumn {
   private final String fieldName;
   private final Field field;
   private final List<MetaDataColumnConstraint> constraints;
+  private final Relation columnRelation;
 
-  private MetaDataColumn(String name, String type, String fieldName, Field field, List<MetaDataColumnConstraint> constraints) {
+  private MetaDataColumn(String name, String type, String fieldName, Field field, List<MetaDataColumnConstraint> constraints,
+      Relation columnRelation) {
     this.name = name;
     this.type = type;
     this.fieldName = fieldName;
     this.field = field;
     this.constraints = constraints;
+    this.columnRelation = columnRelation;
   }
 
   public static MetaDataColumn of(Field field, String columnType) {
@@ -29,8 +32,11 @@ public class MetaDataColumn {
             .map(MetaDataColumnConstraint::of)
             .sorted(Comparator.comparing(MetaDataColumnConstraint::getConstraint).reversed())
             .collect(Collectors.toList());
-
-    return new MetaDataColumn(getDBColumnName(field), columnType, field.getName(), field, constraints);
+//    MetaDataColumnRelation columnRelation = Arrays.stream(field.getAnnotations())
+//        .map(MetaDataColumnRelation::of)
+//        .findAny().orElse(new MetaDataColumnEmptyRelation());
+    return new MetaDataColumn(getDBColumnName(field), columnType, field.getName(), field, constraints,
+        new MetaDataColumnEmptyRelation());
   }
 
   public String getDBColumnsClause() {
@@ -89,5 +95,9 @@ public class MetaDataColumn {
       throw new RuntimeException(e);
     }
     field.setAccessible(false);
+  }
+
+  public boolean isGenerated(){
+    return constraints.stream().anyMatch(constraint -> constraint.isGeneratedKey());
   }
 }

--- a/src/main/java/persistence/meta/MetaDataColumn.java
+++ b/src/main/java/persistence/meta/MetaDataColumn.java
@@ -35,7 +35,7 @@ public class MetaDataColumn {
             .sorted(Comparator.comparing(MetaDataColumnConstraint::getConstraint).reversed())
             .collect(Collectors.toList());
     boolean isRelation = Arrays.stream(field.getAnnotations())
-        .anyMatch(annot -> annot.equals(OneToMany.class) || annot.equals(JoinColumn.class));
+        .anyMatch(annot -> annot.annotationType().equals(OneToMany.class) || annot.annotationType().equals(JoinColumn.class));
 
     Relation relation = isRelation ? MetaDataColumnRelation.of(field) : new MetaDataColumnEmptyRelation();
 

--- a/src/main/java/persistence/meta/MetaDataColumnConstraint.java
+++ b/src/main/java/persistence/meta/MetaDataColumnConstraint.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.util.Arrays;
 
 public class MetaDataColumnConstraint {
+
   private final ConstraintType constraintType;
   private final Annotation annotation;
 
@@ -12,20 +13,24 @@ public class MetaDataColumnConstraint {
     this.annotation = annotation;
   }
 
-  public static MetaDataColumnConstraint of(Annotation annotation){
+  public static MetaDataColumnConstraint of(Annotation annotation) {
     ConstraintType constraintType = Arrays.stream(ConstraintType.values())
-            .filter(constraintGroupType -> constraintGroupType.hasConstraint(annotation))
-            .findFirst()
-            .orElseGet(() -> ConstraintType.EMPTY);
+        .filter(constraintGroupType -> constraintGroupType.hasConstraint(annotation))
+        .findFirst()
+        .orElseGet(() -> ConstraintType.EMPTY);
 
     return new MetaDataColumnConstraint(constraintType, annotation);
   }
 
-  public String getConstraint(){
+  public String getConstraint() {
     return this.constraintType.getConstraintMappingToConstraint(this.annotation);
   }
 
-  public boolean isPrimaryKey(){
+  public boolean isGeneratedKey() {
+    return this.constraintType.equals(ConstraintType.GENERATED_VALUE);
+  }
+
+  public boolean isPrimaryKey() {
     return this.constraintType.equals(ConstraintType.ID);
   }
 }

--- a/src/main/java/persistence/meta/MetaDataColumnEmptyRelation.java
+++ b/src/main/java/persistence/meta/MetaDataColumnEmptyRelation.java
@@ -1,0 +1,39 @@
+package persistence.meta;
+
+import jakarta.persistence.FetchType;
+
+public class MetaDataColumnEmptyRelation implements Relation {
+
+  public MetaDataColumnEmptyRelation() {
+  }
+
+  @Override
+  public boolean isRelation() {
+    return false;
+  }
+
+  @Override
+  public String getDbName() {
+    return null;
+  }
+
+  @Override
+  public FetchType getFetchType() {
+    return null;
+  }
+
+  @Override
+  public MetaEntity<?> getMetaEntity() {
+    return null;
+  }
+
+  @Override
+  public Class<?> getRelation() {
+    return null;
+  }
+
+  @Override
+  public String getFieldName() {
+    return null;
+  }
+}

--- a/src/main/java/persistence/meta/MetaDataColumnRelation.java
+++ b/src/main/java/persistence/meta/MetaDataColumnRelation.java
@@ -1,0 +1,70 @@
+package persistence.meta;
+
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import java.lang.reflect.Field;
+import jakarta.persistence.FetchType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+public class MetaDataColumnRelation implements Relation {
+
+  private final String fieldName;
+  private final String dbName;
+  private final FetchType fetchType;
+  private final MetaEntity<?> metaEntity;
+  private final Class<?> relation;
+
+  public MetaDataColumnRelation(String fieldName,String dbName , FetchType fetchType, MetaEntity<?> metaEntity,
+      Class<?> relation) {
+    this.fieldName = fieldName;
+    this.dbName = dbName;
+    this.fetchType = fetchType;
+    this.metaEntity = metaEntity;
+    this.relation = relation;
+  }
+
+  public static MetaDataColumnRelation of(Field field) {
+
+    String dbName = field.getAnnotation(JoinColumn.class).name();
+    FetchType fetchType = field.getAnnotation(OneToMany.class).fetch();
+    Class<?> relation = OneToMany.class;
+
+    Type type = field.getGenericType();
+    Type actualTypeArgument = ((ParameterizedType) type).getActualTypeArguments()[0];
+
+    return new MetaDataColumnRelation(field.getName(), dbName, fetchType, MetaEntity.of((Class<?>) actualTypeArgument) , relation);
+  }
+
+  @Override
+  public boolean isRelation() {
+    return true;
+  }
+
+  @Override
+  public String getDbName() {
+    return dbName;
+  }
+
+  @Override
+  public FetchType getFetchType() {
+    return fetchType;
+  }
+
+  @Override
+  public MetaEntity<?> getMetaEntity() {
+    return metaEntity;
+  }
+
+  @Override
+  public Class<?> getRelation() {
+    return relation;
+  }
+
+  @Override
+  public String getFieldName() {
+    return fieldName;
+  }
+
+
+}

--- a/src/main/java/persistence/meta/MetaDataColumns.java
+++ b/src/main/java/persistence/meta/MetaDataColumns.java
@@ -1,11 +1,11 @@
 package persistence.meta;
 
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Transient;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import persistence.dialect.Dialect;
 
@@ -14,15 +14,17 @@ public class MetaDataColumns {
   public static final String DELIMITER = ",";
   private final List<MetaDataColumn> columns = new ArrayList<>();
   private final MetaDataColumn primaryColumn;
-
-  private MetaDataColumns(List<MetaDataColumn> metaColumns, MetaDataColumn primaryColumn) {
+  private final Relation relation;
+  private MetaDataColumns(List<MetaDataColumn> metaColumns, MetaDataColumn primaryColumn,
+      Relation relation) {
     this.primaryColumn = primaryColumn;
+    this.relation = relation;
     columns.addAll(metaColumns);
   }
 
   public static MetaDataColumns of(Class<?> clazz, Dialect dialect) {
     List<MetaDataColumn> metaColumns = Arrays.stream(clazz.getDeclaredFields())
-        .filter(field -> isNotTransient(List.of(field.getAnnotations())))
+        .filter(field -> isNotTransient(List.of(field.getAnnotations())) && isNotRelation(List.of(field.getAnnotations())))
         .map(field -> MetaDataColumn.of(field, dialect.convertToColumn(field)))
         .collect(Collectors.toList());
 
@@ -30,11 +32,17 @@ public class MetaDataColumns {
         .filter(column -> !column.isNotPrimaryKey())
         .findFirst().orElseThrow(() -> new RuntimeException("ID 필드가 없습니다."));
 
-    return new MetaDataColumns(metaColumns, primaryKeyColumn);
+    Relation relation = metaColumns.stream()
+        .filter(column -> column.hasRelation())
+        .map(column -> column.getColumnRelation())
+        .findAny().orElse(new MetaDataColumnEmptyRelation());
+
+    return new MetaDataColumns(metaColumns, primaryKeyColumn, relation);
   }
 
   public String getColumns() {
     return columns.stream()
+        .filter(column -> !column.hasRelation())
         .map(MetaDataColumn::getDBColumnsClause)
         .collect(Collectors.joining(DELIMITER));
   }
@@ -44,9 +52,15 @@ public class MetaDataColumns {
         .noneMatch(annotation -> annotation.annotationType().equals(Transient.class));
   }
 
+  private static boolean isNotRelation(List<Annotation> annotations) {
+    return annotations.stream()
+        .noneMatch(annotation -> annotation.annotationType().equals(OneToMany.class));
+  }
+
   public List<String> getDBColumnsWithoutId() {
     return columns.stream()
         .filter(MetaDataColumn::isNotPrimaryKey)
+        .filter(column -> !column.hasRelation())
         .map(MetaDataColumn::getDBColumnName)
         .collect(Collectors.toList());
   }
@@ -59,8 +73,16 @@ public class MetaDataColumns {
 
   public List<String> getColumnsWithId() {
     return columns.stream()
+        .filter(column -> !column.hasRelation())
         .map(MetaDataColumn::getDBColumnName)
         .collect(Collectors.toList());
+  }
+
+  public boolean hasRelation(){
+    return relation.isRelation();
+  }
+  public Relation getRelation(){
+    return relation;
   }
 
   public MetaDataColumn getPrimaryColumn() {

--- a/src/main/java/persistence/meta/MetaDataColumns.java
+++ b/src/main/java/persistence/meta/MetaDataColumns.java
@@ -24,7 +24,7 @@ public class MetaDataColumns {
 
   public static MetaDataColumns of(Class<?> clazz, Dialect dialect) {
     List<MetaDataColumn> metaColumns = Arrays.stream(clazz.getDeclaredFields())
-        .filter(field -> isNotTransient(List.of(field.getAnnotations())) && isNotRelation(List.of(field.getAnnotations())))
+        .filter(field -> isNotTransient(List.of(field.getAnnotations())))
         .map(field -> MetaDataColumn.of(field, dialect.convertToColumn(field)))
         .collect(Collectors.toList());
 
@@ -90,7 +90,7 @@ public class MetaDataColumns {
   }
 
   public List<MetaDataColumn> getMetaDataColumns() {
-    return columns;
+    return columns.stream().filter(column -> !column.hasRelation()).collect(Collectors.toList());
   }
 
   public MetaDataColumn getColumnByFieldName(String fieldName) {

--- a/src/main/java/persistence/meta/MetaEntity.java
+++ b/src/main/java/persistence/meta/MetaEntity.java
@@ -116,6 +116,10 @@ public class MetaEntity<T> {
     return metaDataColumns.getColumnsWithId();
   }
 
+  public boolean hasRelation(){
+    return metaDataColumns.hasRelation();
+  }
+
   public boolean isDbGeneratedKey() {
     return primaryKeyColumn.isGenerated();
   }

--- a/src/main/java/persistence/meta/MetaEntity.java
+++ b/src/main/java/persistence/meta/MetaEntity.java
@@ -112,10 +112,11 @@ public class MetaEntity<T> {
     return metaDataColumns.getFields();
   }
 
-
-  private List<String> getEntityColumnsWithId() {
+  public List<String> getEntityColumnsWithId() {
     return metaDataColumns.getColumnsWithId();
   }
 
-
+  public boolean isDbGeneratedKey() {
+    return primaryKeyColumn.isGenerated();
+  }
 }

--- a/src/main/java/persistence/meta/Relation.java
+++ b/src/main/java/persistence/meta/Relation.java
@@ -1,0 +1,14 @@
+package persistence.meta;
+
+import jakarta.persistence.FetchType;
+
+public interface Relation {
+
+  boolean isRelation();
+
+  String getDbName();
+  FetchType getFetchType();
+  MetaEntity<?> getMetaEntity();
+  Class<?> getRelation();
+  String getFieldName();
+}

--- a/src/main/java/persistence/sql/ddl/builder/CreateQueryBuilder.java
+++ b/src/main/java/persistence/sql/ddl/builder/CreateQueryBuilder.java
@@ -2,12 +2,16 @@ package persistence.sql.ddl.builder;
 
 public class CreateQueryBuilder {
   private static final String CREATE_SQL_QUERY = "CREATE TABLE %s (%s);";
+  private static final String CREATE_IF_NOT_EXISTS_SQL_QUERY = "CREATE TABLE IF NOT EXISTS %s (%s);";
 
   public CreateQueryBuilder() {
+  }
+
+  public String createIfNotExistsCreateQuery(String tableName, String columns) {
+    return String.format(CREATE_IF_NOT_EXISTS_SQL_QUERY, tableName, columns);
   }
 
   public String createCreateQuery(String tableName, String columns) {
     return String.format(CREATE_SQL_QUERY, tableName, columns);
   }
-
 }

--- a/src/main/java/persistence/sql/dml/builder/DmlQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/builder/DmlQueryBuilder.java
@@ -3,21 +3,29 @@ package persistence.sql.dml.builder;
 import java.util.List;
 
 public class DmlQueryBuilder {
+
   private final InsertQueryBuilder insertQueryBuilder = new InsertQueryBuilder();
   private final DeleteQueryBuilder deleteQueryBuilder = new DeleteQueryBuilder();
   private final UpdateQueryBuilder updateQueryBuilder = new UpdateQueryBuilder();
+
   public DmlQueryBuilder() {
   }
 
-  public String createUpdateQuery(String tableName, List<String> columns, List<String> values, String whereColumn, String whereValue){
-    return updateQueryBuilder.createUpdateQuery(tableName, columns, values, whereColumn, whereValue);
+  public String createUpdateQuery(String tableName, List<String> columns, List<String> values,
+      String whereColumn, String whereValue) {
+    return updateQueryBuilder.createUpdateQuery(tableName, columns, values, whereColumn,
+        whereValue);
   }
 
-  public String createInsertQuery(String tableName, String columnClause, String valueClause){
+  public String createInsertQuery(String tableName, String columnClause, String valueClause) {
     return insertQueryBuilder.createInsertQuery(tableName, columnClause, valueClause);
   }
 
-  public String createDeleteQuery(String tableName, String targetName, Object targetValue){
+  public String createDeleteQuery(String tableName, String targetName, Object targetValue) {
     return deleteQueryBuilder.createDeleteQuery(tableName, targetName, targetValue);
+  }
+
+  public JoinQueryBuilder JoinQueryBuilder() {
+    return new JoinQueryBuilder();
   }
 }

--- a/src/main/java/persistence/sql/dml/builder/JoinQuery.java
+++ b/src/main/java/persistence/sql/dml/builder/JoinQuery.java
@@ -9,7 +9,7 @@ public class JoinQuery {
   private static final String SELECT_CLAUSE = "SELECT %s";
   private static final String FROM_CLAUSE = "FROM %s";
   private static final String JOIN_CLAUSE = "JOIN %s ON %s = %s";
-  private static final String WHERE_CLAUSE = "WHERE %s IN [%s]";
+  private static final String WHERE_CLAUSE = "WHERE %s IN (%s)";
   private static final String DELIMITER = ",";
   private static final String SPACE = " ";
   private final String tableName;

--- a/src/main/java/persistence/sql/dml/builder/JoinQuery.java
+++ b/src/main/java/persistence/sql/dml/builder/JoinQuery.java
@@ -1,0 +1,51 @@
+package persistence.sql.dml.builder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class JoinQuery {
+
+  private static final String JOIN_QUERY = "%s %s %s %s;";
+  private static final String SELECT_CLAUSE = "SELECT %s";
+  private static final String FROM_CLAUSE = "FROM %s";
+  private static final String JOIN_CLAUSE = "JOIN %s ON %s = %s";
+  private static final String WHERE_CLAUSE = "WHERE %s IN [%s]";
+  private static final String DELIMITER = ",";
+  private static final String SPACE = " ";
+  private final String tableName;
+  private final List<String> tablesToJoin;
+  private final List<String> foreignKey;
+  private final String targetName;
+  private final List<String> targets;
+  private final String selectClause;
+
+
+  public JoinQuery(String selectClause, String tableName, List<String> tablesToJoin,
+      List<String> foreignKey, String targetName, List<String> targets) {
+    this.selectClause = selectClause;
+    this.tableName = tableName;
+    this.tablesToJoin = tablesToJoin;
+    this.foreignKey = foreignKey;
+    this.targetName = targetName;
+    this.targets = targets;
+  }
+
+  public String createJoinQuery(){
+
+    String select = String.format(SELECT_CLAUSE, selectClause);
+    String from = String.format(FROM_CLAUSE, tableName);
+
+    List<String> joins = new ArrayList<>();
+
+    for (int i = 0; i < tablesToJoin.size(); i++) {
+      joins.add(String.format(JOIN_CLAUSE, tablesToJoin.get(i), targetName,  foreignKey.get(i)));
+    }
+
+    String join = String.join(SPACE, joins);
+
+    String ids = String.join(DELIMITER, targets);
+    String whereClause = String.format(WHERE_CLAUSE, targetName, ids);
+
+    return String.format(JOIN_QUERY, select, from, join, whereClause);
+  }
+}

--- a/src/main/java/persistence/sql/dml/builder/JoinQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/builder/JoinQueryBuilder.java
@@ -20,14 +20,14 @@ public class JoinQueryBuilder {
   private String whereColumn;
   private List<String> whereValues;
 
-  public JoinQueryBuilder select(String tableName, List<String> selectColumnsTable, List<String> selectColumnsTableToJoin){
+  public JoinQueryBuilder select(String tableName, String tablesToJoin, List<String> selectColumnsTable, List<String> selectColumnsTableToJoin){
 
     String selectColumns = selectColumnsTable.stream()
         .map(columnName -> String.join(PERIOD, tableName, columnName))
         .collect(Collectors.joining(DELIMITER));
 
     String selectColumnsJoin = selectColumnsTableToJoin.stream()
-        .map(columnName -> String.join(PERIOD, tableName, columnName))
+        .map(columnName -> String.join(PERIOD, tablesToJoin, columnName))
         .collect(Collectors.joining(DELIMITER));
 
     this.tableName = tableName;

--- a/src/main/java/persistence/sql/dml/builder/JoinQueryBuilder.java
+++ b/src/main/java/persistence/sql/dml/builder/JoinQueryBuilder.java
@@ -1,0 +1,71 @@
+package persistence.sql.dml.builder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/*
+TODO 이제 추상화할 수 있는 부분이 보이네요;;;
+SELECT 절, WHERE 절다 분리가 가능해보이네요
+하나의 클래스에 밀어넣는게 냄새가 나기 시작하네요.
+ */
+public class JoinQueryBuilder {
+  private static final String PERIOD = ".";
+  private static final String DELIMITER = ",";
+  private String selectClause;
+  private String tableName;
+  private List<String> tablesToJoin;
+  private List<String> foreignKey;
+  private String whereColumn;
+  private List<String> whereValues;
+
+  public JoinQueryBuilder select(String tableName, List<String> selectColumnsTable, List<String> selectColumnsTableToJoin){
+
+    String selectColumns = selectColumnsTable.stream()
+        .map(columnName -> String.join(PERIOD, tableName, columnName))
+        .collect(Collectors.joining(DELIMITER));
+
+    String selectColumnsJoin = selectColumnsTableToJoin.stream()
+        .map(columnName -> String.join(PERIOD, tableName, columnName))
+        .collect(Collectors.joining(DELIMITER));
+
+    this.tableName = tableName;
+    selectClause = String.join(DELIMITER, selectColumns, selectColumnsJoin);
+
+    return this;
+  }
+
+  public JoinQueryBuilder join(List<String> tablesToJoin){
+    this.tablesToJoin = tablesToJoin;
+
+    return this;
+  }
+
+  public JoinQueryBuilder on(List<String> foreignKey){
+    if (tablesToJoin.size() != foreignKey.size()){
+      throw new RuntimeException("JOIN ON FK 가 필요합니다.");
+    }
+    List<String> tableForeignKeys = new ArrayList<>();
+
+    for (int i = 0; i < foreignKey.size(); i++) {
+      tableForeignKeys.add(String.join(PERIOD, tablesToJoin.get(i), foreignKey.get(i)));
+    }
+
+    this.foreignKey = tableForeignKeys;
+
+    return this;
+  }
+
+  public JoinQueryBuilder where(String targetName, List<String> targets){
+    this.whereColumn = String.join(PERIOD, List.of(tableName, targetName));
+    this.whereValues = targets;
+
+    return this;
+  }
+
+  public JoinQuery build(){
+    return new JoinQuery(selectClause, tableName, Collections.unmodifiableList(tablesToJoin), Collections.unmodifiableList(foreignKey),
+        whereColumn, Collections.unmodifiableList(whereValues));
+  }
+}

--- a/src/test/java/persistence/entity/CollectionElementLoaderTest.java
+++ b/src/test/java/persistence/entity/CollectionElementLoaderTest.java
@@ -81,6 +81,17 @@ class CollectionElementLoaderTest {
     assertThat(order.orderItems.get(1).product).isEqualTo("두번째 음식");
   }
 
+
+  @Test
+  @DisplayName("Fetch Type이 EAGER인 엔티티를 LOAD할 때, element 엔티티들도 Load 됩니다.")
+  void entityLoadByIdsCollection(){
+    CollectionElementLoader<Order> Loader = (CollectionElementLoader<Order>) CollectionElementLoader.of(Order.class, connection);
+    List<Order> orders = Loader.loadByIds(List.of(1L,2L));
+
+    assertThat(orders).hasSize(1);
+    assertThat(orders.get(0).orderItems.get(0).product).isEqualTo("첫번째 음식");
+    assertThat(orders.get(0).orderItems.get(1).product).isEqualTo("두번째 음식");
+  }
   @Entity
   @Table(name = "orders")
   public static class Order {

--- a/src/test/java/persistence/entity/CollectionElementLoaderTest.java
+++ b/src/test/java/persistence/entity/CollectionElementLoaderTest.java
@@ -1,0 +1,111 @@
+package persistence.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import database.DatabaseServer;
+import database.H2;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import jdbc.JdbcTemplate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import persistence.meta.MetaEntity;
+
+class CollectionElementLoaderTest {
+  public static DatabaseServer server;
+  public static JdbcTemplate jdbcTemplate;
+  public static Connection connection;
+
+  @BeforeAll
+  static void setup() throws SQLException {
+    server = new H2();
+    server.start();
+    connection = server.getConnection();
+    jdbcTemplate = new JdbcTemplate(connection);
+  }
+  @BeforeEach
+  void before(){
+    MetaEntity<Order> parentMeta = MetaEntity.of(Order.class);
+    MetaEntity<OrderItem> elementMeta = MetaEntity.of(OrderItem.class);
+
+    jdbcTemplate.execute(
+        "CREATE TABLE IF NOT EXISTS orders (id BIGINT PRIMARY KEY, number BIGINT)"
+    );
+    jdbcTemplate.execute(
+        "CREATE TABLE IF NOT EXISTS order_items "
+            + "(id BIGINT PRIMARY KEY, order_id BIGINT, number BIGINT, product VARCHAR)"
+    );
+
+    jdbcTemplate.execute(
+        "insert into orders (id, number) values (1, 123)"
+    );
+    jdbcTemplate.execute(
+        "insert into order_items (id, order_id, product, number) values (1, 1, '첫번째 음식', 2323)"
+    );
+    jdbcTemplate.execute(
+        "insert into order_items (id, order_id, product, number) values (2, 1, '두번째 음식', 123)"
+    );
+
+  }
+
+  @AfterEach
+  void after(){
+
+    jdbcTemplate.execute(
+        "truncate table ORDERS RESTART IDENTITY"
+    );
+    jdbcTemplate.execute(
+        "truncate table order_items RESTART IDENTITY"
+    );
+
+
+  }
+  @Test
+  @DisplayName("Fetch Type이 EAGER인 엔티티를 LOAD할 때, element 엔티티들도 Load 됩니다.")
+  void entityLoadCollection(){
+    CollectionElementLoader<Order> Loader = (CollectionElementLoader<Order>) CollectionElementLoader.of(Order.class, connection);
+    Order order = Loader.load(1L).get();
+    
+    assertThat(order.orderItems).hasSize(2);
+    assertThat(order.orderItems.get(0).product).isEqualTo("첫번째 음식");
+    assertThat(order.orderItems.get(1).product).isEqualTo("두번째 음식");
+  }
+
+  @Entity
+  @Table(name = "orders")
+  public static class Order {
+
+    @Id
+    private Long id;
+
+    private Long number;
+
+    @OneToMany(fetch = FetchType.EAGER)
+    @JoinColumn(name = "order_id")
+    private List<OrderItem> orderItems;
+  }
+
+  @Entity
+  @Table(name = "order_items")
+  public static class OrderItem {
+
+    @Id
+    private Long id;
+
+    private String product;
+
+    private Long number;
+  }
+}
+
+

--- a/src/test/java/persistence/entity/JdbcEntityLoaderTest.java
+++ b/src/test/java/persistence/entity/JdbcEntityLoaderTest.java
@@ -3,33 +3,45 @@ package persistence.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import persistence.sql.ddl.builder.BuilderTest;
 import persistence.sql.fixture.PersonFixtureStep3;
-import persistence.sql.fixture.PersonInstances;
 
 public class JdbcEntityLoaderTest extends BuilderTest {
-  @Test
-  @DisplayName("Loader를 이용해서 find 합니다.")
-  public void findEntity() {
-    JdbcEntityLoader<PersonFixtureStep3> jdbcEntityLoader = new JdbcEntityLoader<>(PersonFixtureStep3.class, connection);
-    List<PersonFixtureStep3> people = jdbcEntityLoader.findAll();
-    PersonFixtureStep3 person = jdbcEntityLoader.load(2L).get();
 
-    assertThat(person).isEqualTo(PersonInstances.두번째사람);
+  public static final long ID = 50L;
+  public static final long ID1 = 51L;
+  PersonFixtureStep3 첫번째사람 = new PersonFixtureStep3(ID, "제임스", 21, "sdafij@gmail.com");
+  PersonFixtureStep3 두번째사람 = new PersonFixtureStep3(ID1, "사이먼", 23, "sdafij@gmail.com");
+
+  @BeforeEach
+  void insert() {
+    persistenceContext = new JdbcPersistenceContext();
+
+    String queryFirst = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER, String.valueOf(ID), meta.getValueClause(첫번째사람)));
+    String querySecond = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER, String.valueOf(ID1), meta.getValueClause(두번째사람)));
+
+    jdbcTemplate.execute(queryFirst);
+    jdbcTemplate.execute(querySecond);
   }
 
   @Test
   @DisplayName("Loader를 이용해서 find 합니다.")
+  public void findEntity() {
+    JdbcEntityLoader<PersonFixtureStep3> jdbcEntityLoader = new JdbcEntityLoader<>(PersonFixtureStep3.class, connection);
+    PersonFixtureStep3 person = jdbcEntityLoader.load(ID1).get();
+
+    assertThat(person).isEqualTo(두번째사람);
+  }
+
+  @Test
+  @DisplayName("Loader를 이용해서 findAll 합니다.")
   public void findAllEntity() {
     JdbcEntityLoader<PersonFixtureStep3> jdbcEntityLoader = new JdbcEntityLoader<>(PersonFixtureStep3.class, connection);
-    String queryFirst = insertQueryBuilder.createInsertQuery(meta.getTableName(),
-        meta.getColumnClause(), meta.getValueClause(PersonInstances.첫번째사람));
-    String querySecond = insertQueryBuilder.createInsertQuery(meta.getTableName(),
-        meta.getColumnClause(), meta.getValueClause(PersonInstances.두번째사람));
-    jdbcTemplate.execute(queryFirst);
-    jdbcTemplate.execute(querySecond);
 
     List<PersonFixtureStep3> people = jdbcEntityLoader.findAll();
 

--- a/src/test/java/persistence/entity/JdbcEntityManagerTest.java
+++ b/src/test/java/persistence/entity/JdbcEntityManagerTest.java
@@ -2,52 +2,72 @@ package persistence.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import persistence.sql.ddl.builder.BuilderTest;
 import persistence.sql.fixture.PersonFixtureStep3;
-import persistence.sql.fixture.PersonInstances;
 
 public class JdbcEntityManagerTest extends BuilderTest {
+  public static final long ID = 60L;
+  public static final long ID1 = 61L;
+  public static final long ID2 = 62L;
+  PersonFixtureStep3 첫번째사람 = new PersonFixtureStep3(ID, "제임스", 21, "sdafij@gmail.com");
+  PersonFixtureStep3 두번째사람 = new PersonFixtureStep3(ID1, "사이먼", 23, "sdafij@gmail.com");
+  PersonFixtureStep3 세번째사람 = new PersonFixtureStep3(ID2, "사이먼", 23, "sdafij@gmail.com");
+
+  @BeforeEach
+  void insert() {
+    persistenceContext = new JdbcPersistenceContext();
+
+    String queryFirst = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER, String.valueOf(ID), meta.getValueClause(첫번째사람)));
+    String querySecond = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER, String.valueOf(ID1), meta.getValueClause(두번째사람)));
+    String queryThird = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER, String.valueOf(ID2), meta.getValueClause(세번째사람)));
+
+    jdbcTemplate.execute(queryFirst);
+    jdbcTemplate.execute(querySecond);
+    jdbcTemplate.execute(queryThird);
+  }
   @Test
   @DisplayName("EntityManager를 이용해서 find 합니다.")
   public void findEntity() {
     JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
         entityEntry);
 
-    PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 2L);
+    PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, ID1);
 
-    assertThat(person).isEqualTo(PersonInstances.두번째사람);
-    assertThat(entityEntry.getEntityStatus(PersonInstances.두번째사람)).isEqualTo(EntityStatus.MANAGED);
+    assertThat(person).isEqualTo(두번째사람);
+    assertThat(entityEntry.getEntityStatus(두번째사람)).isEqualTo(EntityStatus.MANAGED);
   }
 
   @Test
   @DisplayName("EntityManager를 이용해서 persist 합니다.")
   public void persistEntity() {
-    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
-        entityEntry);
+    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext, entityEntry);
 
-    jdbcEntityManager.persist(PersonInstances.세번째사람);
+    jdbcEntityManager.persist(세번째사람);
 
-    assertThat(entityEntry.getEntityStatus(PersonInstances.세번째사람)).isEqualTo(EntityStatus.MANAGED);
+    assertThat(entityEntry.getEntityStatus(세번째사람)).isEqualTo(EntityStatus.MANAGED);
 
-    PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 3L);
+    PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, ID2);
 
-    assertThat(person).isEqualTo(PersonInstances.세번째사람);
-    assertThat(entityEntry.getEntityStatus(PersonInstances.세번째사람)).isEqualTo(EntityStatus.LOADING);
+    assertThat(person).isEqualTo(세번째사람);
+    assertThat(entityEntry.getEntityStatus(세번째사람)).isEqualTo(EntityStatus.LOADING);
   }
 
   @Test
   @DisplayName("EntityManager를 이용해서 remove 하고 조회하였을 때, 해당 row가 없습니다.")
   public void removeEntity() {
-    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
-        entityEntry);
+    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext, entityEntry);
 
-    jdbcEntityManager.remove(PersonInstances.첫번째사람);
-    PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 1L);
+    jdbcEntityManager.remove(첫번째사람);
+    PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, ID);
 
     assertThat(person).isEqualTo(null);
-    assertThat(entityEntry.getEntityStatus(PersonInstances.첫번째사람)).isEqualTo(EntityStatus.GONE);
+    assertThat(entityEntry.getEntityStatus(첫번째사람)).isEqualTo(EntityStatus.GONE);
   }
   @Test
   @DisplayName("find시에 1차 캐시에 저장된 entity를 가져온다.")
@@ -55,12 +75,12 @@ public class JdbcEntityManagerTest extends BuilderTest {
     JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
         entityEntry);
 
-    jdbcEntityManager.persist(PersonInstances.두번째사람);
-    PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 2L);
+    jdbcEntityManager.persist(두번째사람);
+    PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, ID1);
 
-    assertThat(person).isEqualTo(PersonInstances.두번째사람);
-    assertThat(person == PersonInstances.두번째사람).isEqualTo(true);
-    assertThat(entityEntry.getEntityStatus(PersonInstances.두번째사람)).isEqualTo(EntityStatus.LOADING);
+    assertThat(person).isEqualTo(두번째사람);
+    assertThat(person == 두번째사람).isEqualTo(true);
+    assertThat(entityEntry.getEntityStatus(두번째사람)).isEqualTo(EntityStatus.LOADING);
   }
 
   @Test
@@ -69,12 +89,12 @@ public class JdbcEntityManagerTest extends BuilderTest {
     JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
         entityEntry);
 
-    PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 2L);
+    PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, ID1);
     person.setName("Sichngpark");
 
     jdbcEntityManager.persist(person);
     
-    PersonFixtureStep3 personInCache = jdbcEntityManager.find(PersonFixtureStep3.class, 2L);
+    PersonFixtureStep3 personInCache = jdbcEntityManager.find(PersonFixtureStep3.class, ID1);
 
     assertThat(personInCache.getName()).isEqualTo("Sichngpark");
   }

--- a/src/test/java/persistence/entity/JdbcEntityPersisterTest.java
+++ b/src/test/java/persistence/entity/JdbcEntityPersisterTest.java
@@ -3,14 +3,35 @@ package persistence.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import persistence.sql.ddl.builder.BuilderTest;
 import persistence.sql.fixture.PersonFixtureStep3;
-import persistence.sql.fixture.PersonInstances;
 
 public class JdbcEntityPersisterTest extends BuilderTest {
 
+  public static final long ID = 70L;
+  public static final long ID1 = 71L;
+  public static final long ID2 = 72L;
+  PersonFixtureStep3 첫번째사람 = new PersonFixtureStep3(ID, "제임스", 21, "sdafij@gmail.com");
+  PersonFixtureStep3 두번째사람 = new PersonFixtureStep3(ID1, "사이먼", 23, "sdafij@gmail.com");
+  PersonFixtureStep3 세번째사람 = new PersonFixtureStep3(ID2, "사이먼", 23, "sdafij@gmail.com");
+  @BeforeEach
+  void insert() {
+    persistenceContext = new JdbcPersistenceContext();
+
+    String queryFirst = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER, String.valueOf(ID), meta.getValueClause(첫번째사람)));
+    String querySecond = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER, String.valueOf(ID1), meta.getValueClause(두번째사람)));
+    String queryThird = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER, String.valueOf(ID2), meta.getValueClause(세번째사람)));
+
+    jdbcTemplate.execute(queryFirst);
+    jdbcTemplate.execute(querySecond);
+    jdbcTemplate.execute(queryThird);
+  }
   @Test
   @DisplayName("Persister를 이용해서 insert 합니다.")
   public void persisterInsertEntity() {
@@ -28,16 +49,13 @@ public class JdbcEntityPersisterTest extends BuilderTest {
   @Test
   @DisplayName("Persister를 이용해서 update 합니다.")
   public void persisterUpdateEntity() {
-    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
-        entityEntry);
+    JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext, entityEntry);
     JdbcEntityPersister<PersonFixtureStep3> persister = new JdbcEntityPersister<>(PersonFixtureStep3.class, connection);
-    PersonFixtureStep3 업데이트된세번째사람 = new PersonFixtureStep3(3L, "헨드릭스", 24, "sdafij@gmail.com");
+    PersonFixtureStep3 업데이트된세번째사람 = new PersonFixtureStep3(ID2, "헨드릭스", 24, "sdafij@gmail.com");
 
-
-    persister.insert(PersonInstances.세번째사람);
     boolean execute = persister.update(업데이트된세번째사람);
 
-    PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, 3L);
+    PersonFixtureStep3 person = jdbcEntityManager.find(PersonFixtureStep3.class, ID2);
 
     assertThat(execute).isEqualTo(false);
     assertThat(person).isEqualTo(업데이트된세번째사람);
@@ -49,11 +67,10 @@ public class JdbcEntityPersisterTest extends BuilderTest {
     JdbcEntityManager jdbcEntityManager = new JdbcEntityManager(connection, persistenceContext,
         entityEntry);
     JdbcEntityPersister<PersonFixtureStep3> persister = new JdbcEntityPersister<>(PersonFixtureStep3.class, connection);
-    persister.insert(PersonInstances.두번째사람);
 
-    persister.delete(PersonInstances.두번째사람);
+    persister.delete(두번째사람);
 
-    assertThat(jdbcEntityManager.find(PersonFixtureStep3.class, 3L)).isEqualTo(null);
+    assertThat(jdbcEntityManager.find(PersonFixtureStep3.class, ID1)).isEqualTo(null);
   }
 
   @Test

--- a/src/test/java/persistence/entity/JdbcPersistenceContextTest.java
+++ b/src/test/java/persistence/entity/JdbcPersistenceContextTest.java
@@ -3,6 +3,7 @@ package persistence.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import persistence.sql.ddl.builder.BuilderTest;
@@ -10,6 +11,24 @@ import persistence.sql.fixture.PersonFixtureStep3;
 import persistence.sql.fixture.PersonInstances;
 
 public class JdbcPersistenceContextTest extends BuilderTest {
+
+  public static final long ID = 80L;
+  public static final long ID1 = 81L;
+  public static final long ID2 = 82L;
+  PersonFixtureStep3 첫번째사람 = new PersonFixtureStep3(ID, "제임스", 21, "sdafij@gmail.com");
+  PersonFixtureStep3 두번째사람 = new PersonFixtureStep3(ID1, "사이먼", 23, "sdafij@gmail.com");
+  PersonFixtureStep3 세번째사람 = new PersonFixtureStep3(ID2, "사이먼", 23, "sdafij@gmail.com");
+  @BeforeEach
+  void insert() {
+    persistenceContext = new JdbcPersistenceContext();
+
+    String queryFirst = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER, String.valueOf(ID), meta.getValueClause(첫번째사람)));
+    String querySecond = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER, String.valueOf(ID1), meta.getValueClause(두번째사람)));
+    jdbcTemplate.execute(queryFirst);
+    jdbcTemplate.execute(querySecond);
+  }
 
   public static PersistenceContext persistenceContext;
 

--- a/src/test/java/persistence/jdbc/JdbcRowMapperTest.java
+++ b/src/test/java/persistence/jdbc/JdbcRowMapperTest.java
@@ -23,6 +23,7 @@ public class JdbcRowMapperTest {
             "1L, 사이몬, 21, safasd@asmsdf.com\n";
 
     ResultSet rs = new Csv().read(new StringReader(csv), new String[] {"id","name", "age","email"});
+    rs.next();
 
     JdbcRowMapper<PersonFixtureMapper> jdbcRowMapper = new JdbcRowMapper(MetaEntity.of(PersonFixtureMapper.class));
     PersonFixtureMapper person = jdbcRowMapper.mapRow(rs);

--- a/src/test/java/persistence/repository/CustomJpaRepositoryTest.java
+++ b/src/test/java/persistence/repository/CustomJpaRepositoryTest.java
@@ -2,22 +2,35 @@ package persistence.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import persistence.entity.JdbcEntityManager;
+import persistence.entity.JdbcPersistenceContext;
 import persistence.sql.ddl.builder.BuilderTest;
 import persistence.sql.fixture.PersonFixtureStep3;
 import persistence.sql.fixture.PersonInstances;
 
 public class CustomJpaRepositoryTest extends BuilderTest {
+  public static final long ID = 80L;
+  public static final long ID1 = 81L;
+  public static final long ID2 = 82L;
+  PersonFixtureStep3 첫번째사람 = new PersonFixtureStep3(ID, "제임스", 21, "sdafij@gmail.com");
+  PersonFixtureStep3 두번째사람 = new PersonFixtureStep3(ID1, "사이먼", 23, "sdafij@gmail.com");
+  PersonFixtureStep3 세번째사람 = new PersonFixtureStep3(ID2, "사이먼", 23, "sdafij@gmail.com");
 
+  @BeforeEach
+  void insert() {
+    persistenceContext = new JdbcPersistenceContext();
+
+  }
   private CustomJpaRepository<PersonFixtureStep3, Long> customJpaRepository;
   @Test
   @DisplayName("entity를 저장합니다.")
   void saveEntity(){
     customJpaRepository = new CustomJpaRepository<>(new JdbcEntityManager(connection, persistenceContext,
         entityEntry));
-    PersonFixtureStep3 person = customJpaRepository.save(PersonInstances.세번째사람);
+    PersonFixtureStep3 person = customJpaRepository.save(세번째사람);
 
     PersonFixtureStep3 personFound = customJpaRepository.findById(person, person.getId());
 
@@ -30,7 +43,7 @@ public class CustomJpaRepositoryTest extends BuilderTest {
   void persistUpdatedEntity(){
     customJpaRepository = new CustomJpaRepository<>(new JdbcEntityManager(connection, persistenceContext,
         entityEntry));
-    PersonFixtureStep3 person = customJpaRepository.save(PersonInstances.세번째사람);
+    PersonFixtureStep3 person = customJpaRepository.save(세번째사람);
 
     customJpaRepository.save(person);
     person.setName("사이먼팍");

--- a/src/test/java/persistence/sql/ddl/builder/BuilderTest.java
+++ b/src/test/java/persistence/sql/ddl/builder/BuilderTest.java
@@ -31,6 +31,7 @@ public class BuilderTest {
   public static Connection connection;
   public static PersistenceContext persistenceContext;
   public static EntityEntry entityEntry;
+  public static String DELIMITER = ",";
 
   @BeforeAll
   static void setup() throws SQLException {

--- a/src/test/java/persistence/sql/ddl/builder/BuilderTest.java
+++ b/src/test/java/persistence/sql/ddl/builder/BuilderTest.java
@@ -46,7 +46,7 @@ public class BuilderTest {
     insertQueryBuilder = new InsertQueryBuilder();
     createQueryBuilder = new CreateQueryBuilder();
     selectQueryBuilder = new SelectQueryBuilder();
-    String query = createQueryBuilder.createCreateQuery(meta.getTableName(), meta.getColumns());
+    String query = createQueryBuilder.createIfNotExistsCreateQuery(meta.getTableName(), meta.getColumns());
     jdbcTemplate.execute(query);
   }
 

--- a/src/test/java/persistence/sql/dml/builder/DeleteQueryBuilderTest.java
+++ b/src/test/java/persistence/sql/dml/builder/DeleteQueryBuilderTest.java
@@ -3,20 +3,42 @@ package persistence.sql.dml.builder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import persistence.entity.JdbcPersistenceContext;
 import persistence.sql.ddl.builder.BuilderTest;
 import persistence.sql.fixture.PersonFixtureStep3;
 
 @DisplayName("4. 요구사항 DELETE 구현하기")
 public class DeleteQueryBuilderTest extends BuilderTest {
 
+  public static final long TARGET_VALUE = 1L;
+  public static final long ID = 10L;
+  public static final long ID1 = 11L;
+
+  PersonFixtureStep3 첫번째사람 = new PersonFixtureStep3(ID, "제임스", 21, "sdafij@gmail.com");
+  PersonFixtureStep3 두번째사람 = new PersonFixtureStep3(ID1, "사이먼", 23, "sdafij@gmail.com");
+  @BeforeEach
+  void insert() {
+    persistenceContext = new JdbcPersistenceContext();
+
+
+
+    String queryFirst = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER,String.valueOf(ID), meta.getValueClause(첫번째사람)));
+    String querySecond = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER,String.valueOf(ID1), meta.getValueClause(두번째사람)));
+
+    jdbcTemplate.execute(queryFirst);
+    jdbcTemplate.execute(querySecond);
+  }
   @Test
   @DisplayName("Delete SQL 구문을 생성합니다.")
   public void deleteDMLfromEntity() {
     DeleteQueryBuilder deleteQueryBuilder = new DeleteQueryBuilder();
 
-    String query = deleteQueryBuilder.createDeleteQuery("USERS", "id", 1L);
+    String query = deleteQueryBuilder.createDeleteQuery("USERS", "id", TARGET_VALUE);
 
     assertThat(query).isEqualTo("DELETE FROM USERS WHERE id = 1;");
   }
@@ -27,7 +49,7 @@ public class DeleteQueryBuilderTest extends BuilderTest {
   public void deleteDMLfromEntitySQL() {
     DeleteQueryBuilder deleteQueryBuilder = new DeleteQueryBuilder();
     SelectQueryBuilder selectQueryBuilder = new SelectQueryBuilder();
-    Long targetId = 1L;
+    Long targetId = 10L;
 
     String queryDelete = deleteQueryBuilder.createDeleteQuery(meta.getTableName(), meta.getPrimaryKeyColumn().getDBColumnName(), targetId);
     jdbcTemplate.execute(queryDelete);

--- a/src/test/java/persistence/sql/dml/builder/InsertQueryBuilderTest.java
+++ b/src/test/java/persistence/sql/dml/builder/InsertQueryBuilderTest.java
@@ -2,24 +2,43 @@ package persistence.sql.dml.builder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.sql.SQLException;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import persistence.meta.MetaEntity;
+import persistence.entity.JdbcPersistenceContext;
 import persistence.sql.ddl.builder.BuilderTest;
 import persistence.sql.fixture.PersonFixtureStep3;
-import persistence.sql.fixture.PersonInstances;
 
 @DisplayName("1.요구사항 Insert 구현하기")
 public class InsertQueryBuilderTest extends BuilderTest {
+
+
+  public static final long ID = 21L;
+  public static final long ID1 = 22L;
+
+  PersonFixtureStep3 첫번째사람 = new PersonFixtureStep3(ID, "제임스", 21, "sdafij@gmail.com");
+  PersonFixtureStep3 두번째사람 = new PersonFixtureStep3(ID1, "사이먼", 23, "sdafij@gmail.com");
+  @BeforeEach
+  void insert() {
+    persistenceContext = new JdbcPersistenceContext();
+
+    String queryFirst = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER,String.valueOf(ID), meta.getValueClause(첫번째사람)));
+    String querySecond = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER,String.valueOf(ID1), meta.getValueClause(두번째사람)));
+
+    jdbcTemplate.execute(queryFirst);
+    jdbcTemplate.execute(querySecond);
+  }
 
   @Test
   @DisplayName("Insert SQL 구문을 생성합니다.")
   public void insertDMLfromEntity() {
     InsertQueryBuilder insertQueryBuilder = new InsertQueryBuilder();
 
-    String query = insertQueryBuilder.createInsertQuery("USERS", "nick_name,old,email", "'제임스',21,'sdafij@gmail.com'");
+    String query = insertQueryBuilder.createInsertQuery("USERS", "nick_name,old,email",
+        "'제임스',21,'sdafij@gmail.com'");
 
     assertThat(query).isEqualTo(
         "INSERT INTO USERS (nick_name,old,email) values ('제임스',21,'sdafij@gmail.com');");
@@ -27,14 +46,7 @@ public class InsertQueryBuilderTest extends BuilderTest {
 
   @Test
   @DisplayName("Insert SQL 구문을 생성하고 Select 쿼리 실행시에 Entity들이 반환됩니다.")
-  public void insertDMLfromEntityDatabase() throws SQLException {
-
-    InsertQueryBuilder insertQueryBuilder = new InsertQueryBuilder();
-    person = PersonFixtureStep3.class;
-    meta = MetaEntity.of(person);
-    String query = insertQueryBuilder.createInsertQuery(meta.getTableName(), meta.getColumnClause(), meta.getValueClause(PersonInstances.첫번째사람));
-
-    jdbcTemplate.execute(query);
+  public void insertDMLfromEntityDatabase() {
 
     List<Object> people = jdbcTemplate.query("select * from users", (rs) ->
         new PersonFixtureStep3(
@@ -43,8 +55,8 @@ public class InsertQueryBuilderTest extends BuilderTest {
             rs.getInt("old"),
             rs.getString("email")
         ));
-    assertThat(people).contains(PersonInstances.첫번째사람);
 
+    assertThat(people).contains(첫번째사람);
   }
 
 }

--- a/src/test/java/persistence/sql/dml/builder/JoinQueryBuilderTest.java
+++ b/src/test/java/persistence/sql/dml/builder/JoinQueryBuilderTest.java
@@ -18,13 +18,13 @@ public class JoinQueryBuilderTest {
     MetaEntity<OrderItem> metaOrderItem = MetaEntity.of(OrderItem.class);
 
     String joinQuery = new JoinQueryBuilder()
-        .select(metaOrder.getTableName(), metaOrder.getEntityColumnsWithId(), metaOrderItem.getEntityColumnsWithId())
+        .select(metaOrder.getTableName(),metaOrderItem.getTableName(), metaOrder.getEntityColumnsWithId(), metaOrderItem.getEntityColumnsWithId())
         .join(List.of(metaOrderItem.getTableName()))
         .on(List.of("order_id"))
         .where(metaOrder.getPrimaryKeyColumn().getDBColumnName(), List.of("1", "2"))
         .build().createJoinQuery();
 
     assertThat(joinQuery).isEqualTo(
-        "SELECT ORDERS.id,ORDERS.ordernumber,ORDERS.id,ORDERS.product,ORDERS.quantity FROM ORDERS JOIN ORDER_ITEMS ON ORDERS.id = ORDER_ITEMS.order_id WHERE ORDERS.id IN [1,2];");
+        "SELECT ORDERS.id,ORDERS.ordernumber,ORDER_ITEMS.id,ORDER_ITEMS.product,ORDER_ITEMS.quantity FROM ORDERS JOIN ORDER_ITEMS ON ORDERS.id = ORDER_ITEMS.order_id WHERE ORDERS.id IN (1,2);");
   }
 }

--- a/src/test/java/persistence/sql/dml/builder/JoinQueryBuilderTest.java
+++ b/src/test/java/persistence/sql/dml/builder/JoinQueryBuilderTest.java
@@ -1,0 +1,30 @@
+package persistence.sql.dml.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import domain.Order;
+import domain.OrderItem;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import persistence.meta.MetaEntity;
+
+public class JoinQueryBuilderTest {
+
+  @Test
+  @DisplayName("Join SQL 구문을 생성합니다.")
+  public void createJoinSQL() {
+    MetaEntity<Order> metaOrder = MetaEntity.of(Order.class);
+    MetaEntity<OrderItem> metaOrderItem = MetaEntity.of(OrderItem.class);
+
+    String joinQuery = new JoinQueryBuilder()
+        .select(metaOrder.getTableName(), metaOrder.getEntityColumnsWithId(), metaOrderItem.getEntityColumnsWithId())
+        .join(List.of(metaOrderItem.getTableName()))
+        .on(List.of("order_id"))
+        .where(metaOrder.getPrimaryKeyColumn().getDBColumnName(), List.of("1", "2"))
+        .build().createJoinQuery();
+
+    assertThat(joinQuery).isEqualTo(
+        "SELECT ORDERS.id,ORDERS.ordernumber,ORDERS.id,ORDERS.product,ORDERS.quantity FROM ORDERS JOIN ORDER_ITEMS ON ORDERS.id = ORDER_ITEMS.order_id WHERE ORDERS.id IN [1,2];");
+  }
+}

--- a/src/test/java/persistence/sql/dml/builder/SelectQueryBuilderTest.java
+++ b/src/test/java/persistence/sql/dml/builder/SelectQueryBuilderTest.java
@@ -3,8 +3,10 @@ package persistence.sql.dml.builder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import persistence.entity.JdbcPersistenceContext;
 import persistence.sql.ddl.builder.BuilderTest;
 import persistence.sql.fixture.PersonFixtureStep3;
 import persistence.sql.fixture.PersonInstances;
@@ -12,6 +14,22 @@ import persistence.sql.fixture.PersonInstances;
 @DisplayName("2. 요구사항 SELECT 구현하기, 3. 요구사항 WHERE 구현하기")
 public class SelectQueryBuilderTest extends BuilderTest {
 
+  public static final long ID = 31L;
+  public static final long ID1 = 32L;
+  PersonFixtureStep3 첫번째사람 = new PersonFixtureStep3(ID, "제임스", 21, "sdafij@gmail.com");
+  PersonFixtureStep3 두번째사람 = new PersonFixtureStep3(ID1, "사이먼", 23, "sdafij@gmail.com");
+  @BeforeEach
+  void insert() {
+    persistenceContext = new JdbcPersistenceContext();
+
+    String queryFirst = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER,String.valueOf(ID), meta.getValueClause(첫번째사람)));
+    String querySecond = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER,String.valueOf(ID1), meta.getValueClause(두번째사람)));
+
+    jdbcTemplate.execute(queryFirst);
+    jdbcTemplate.execute(querySecond);
+  }
   @Test
   @DisplayName("SELECT SQL 구문을 생성합니다.")
   public void selectDMLfromEntity() {
@@ -26,18 +44,18 @@ public class SelectQueryBuilderTest extends BuilderTest {
   @DisplayName("SELECT SQL 구문을 Where 문과 함께 생성합니다.")
   public void selectDMLWithWherefromEntity() {
     SelectQueryBuilder selectQueryBuilder = new SelectQueryBuilder();
-    Long targetValue = 1L;
+    Long targetValue = 31L;
 
     String query = selectQueryBuilder.createSelectByFieldQuery(meta.getColumnClauseWithId(), meta.getTableName(), meta.getPrimaryKeyColumn().getDBColumnName(), targetValue);
 
-    assertThat(query).isEqualTo("SELECT id,nick_name,old,email FROM USERS WHERE id=1;");
+    assertThat(query).isEqualTo("SELECT id,nick_name,old,email FROM USERS WHERE id=31;");
   }
 
   @Test
   @DisplayName("Select 쿼리 실행시에 Entity들이 반환됩니다.")
   public void selectDMLfromEntityWhereDatabase() {
     SelectQueryBuilder selectQueryBuilder = new SelectQueryBuilder();
-    Long targetValue = 1L;
+    Long targetValue = 31L;
 
     String query = selectQueryBuilder.createSelectByFieldQuery(meta.getColumnClauseWithId(), meta.getTableName(), meta.getPrimaryKeyColumn().getDBColumnName(), targetValue);
 
@@ -48,7 +66,7 @@ public class SelectQueryBuilderTest extends BuilderTest {
                     rs.getInt("old"),
                     rs.getString("email")
             ));
-    assertThat(people).contains(PersonInstances.첫번째사람);
+    assertThat(people).contains(첫번째사람);
 
   }
 }

--- a/src/test/java/persistence/sql/dml/builder/UpdateQueryBuilderTest.java
+++ b/src/test/java/persistence/sql/dml/builder/UpdateQueryBuilderTest.java
@@ -3,38 +3,58 @@ package persistence.sql.dml.builder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import persistence.entity.JdbcPersistenceContext;
 import persistence.sql.ddl.builder.BuilderTest;
 import persistence.sql.fixture.PersonFixtureStep3;
+import persistence.sql.fixture.PersonInstances;
 
 public class UpdateQueryBuilderTest extends BuilderTest {
 
+  public static final long ID = 41L;
+  public static final long ID1 = 42L;
+  PersonFixtureStep3 첫번째사람 = new PersonFixtureStep3(ID, "제임스", 21, "sdafij@gmail.com");
+  PersonFixtureStep3 두번째사람 = new PersonFixtureStep3(ID1, "사이먼", 23, "sdafij@gmail.com");
+
+  @BeforeEach
+  void insert() {
+    persistenceContext = new JdbcPersistenceContext();
+
+    String queryFirst = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER,String.valueOf(ID), meta.getValueClause(첫번째사람)));
+    String querySecond = insertQueryBuilder.createInsertQuery(meta.getTableName(),
+        meta.getColumnClauseWithId(), String.join(DELIMITER,String.valueOf(ID1), meta.getValueClause(두번째사람)));
+
+    jdbcTemplate.execute(queryFirst);
+    jdbcTemplate.execute(querySecond);
+  }
   @Test
   @DisplayName("UPDATE SQL 구문을 생성합니다.")
   public void generateUpdateDML() {
     UpdateQueryBuilder updateQueryBuilder = new UpdateQueryBuilder();
 
     String query = updateQueryBuilder.createUpdateQuery("USERS", List.of("nick_name"),
-        List.of("'value2'"), "ID", "6");
+        List.of("'value2'"), "ID", "41");
 
     assertThat(query).isEqualTo(
-        "UPDATE USERS SET nick_name = 'value2' WHERE ID = 6;");
+        "UPDATE USERS SET nick_name = 'value2' WHERE ID = 41;");
   }
 
   @Test
   @DisplayName("UPDATE 실행하고 SELECT 시에 Entity가 변경되어있습니다.")
   public void insertDMLfromEntity() {
-    PersonFixtureStep3 afterUpdatedPerson = new PersonFixtureStep3(1L, "value2", 21,
+    PersonFixtureStep3 afterUpdatedPerson = new PersonFixtureStep3(41L, "value2", 21,
         "sdafij@gmail.com");
     UpdateQueryBuilder updateQueryBuilder = new UpdateQueryBuilder();
 
     String query = updateQueryBuilder.createUpdateQuery("USERS", List.of("nick_name"),
-        List.of("'value2'"), "ID", "1");
+        List.of("'value2'"), "ID", "41");
 
     jdbcTemplate.execute(query);
 
-    List<Object> people = jdbcTemplate.query("SELECT id,nick_name,old,email FROM USERS WHERE id=1;",
+    List<Object> people = jdbcTemplate.query("SELECT id,nick_name,old,email FROM USERS WHERE id=41;",
         (rs) ->
             new PersonFixtureStep3(
                 rs.getLong("id"),

--- a/src/test/java/persistence/sql/fixture/PersonFixtureStep3.java
+++ b/src/test/java/persistence/sql/fixture/PersonFixtureStep3.java
@@ -2,8 +2,6 @@ package persistence.sql.fixture;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
@@ -14,7 +12,6 @@ import java.util.Objects;
 public class PersonFixtureStep3 {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @Column(name = "nick_name")

--- a/src/test/java/study/HelloTarget.java
+++ b/src/test/java/study/HelloTarget.java
@@ -1,0 +1,15 @@
+package study;
+
+public class HelloTarget {
+  public String sayHello(String name) {
+    return "Hello " + name;
+  }
+
+  public String sayHi(String name) {
+    return "Hi " + name;
+  }
+
+  public String sayThankYou(String name) {
+    return "Thank You " + name;
+  }
+}

--- a/src/test/java/study/ProxyTest.java
+++ b/src/test/java/study/ProxyTest.java
@@ -1,0 +1,84 @@
+package study;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.lang.reflect.Method;
+
+import net.sf.cglib.proxy.Enhancer;
+import net.sf.cglib.proxy.LazyLoader;
+import net.sf.cglib.proxy.MethodInterceptor;
+import net.sf.cglib.proxy.MethodProxy;
+import net.sf.cglib.proxy.NoOp;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import persistence.sql.fixture.PersonFixtureStep3;
+import persistence.sql.fixture.PersonInstances;
+
+public class ProxyTest {
+  @Test
+  @DisplayName("프록시를 사용해 클래스가 RETURN 하는 값을 그대로 return 합니다.")
+  void proxyToSame(){
+    Enhancer enhancer = new Enhancer();
+
+    enhancer.setSuperclass(HelloTarget.class);
+    enhancer.setCallback(NoOp.INSTANCE);
+
+    Object proxy = enhancer.create();
+    HelloTarget helloTarget = (HelloTarget) proxy;
+
+    assertThat(helloTarget.sayHello("simon")).isEqualTo("Hello simon");
+    assertThat(helloTarget.sayHi("simon")).isEqualTo("Hi simon");
+    assertThat(helloTarget.sayThankYou("simon")).isEqualTo("Thank You simon");
+  }
+
+  @Test
+  @DisplayName("프록시를 사용해 클래스가 RETURN 하는 값을 대문자로 변경하였습니다.")
+  void proxyToCapital(){
+    Enhancer enhancer = new Enhancer();
+
+    enhancer.setSuperclass(HelloTarget.class);
+    enhancer.setCallback(new MethodCallLogInterceptor());
+
+    Object proxy = enhancer.create();
+    HelloTarget helloTarget = (HelloTarget) proxy;
+
+    assertThat(helloTarget.sayHello("simon")).isEqualTo("HELLO SIMON");
+    assertThat(helloTarget.sayHi("simon")).isEqualTo("HI SIMON");
+    assertThat(helloTarget.sayThankYou("simon")).isEqualTo("THANK YOU SIMON");
+  }
+  @Test
+  @DisplayName("프록시를 사용해 클래스가 lazyLoading을 합니다.")
+  void proxyToLazyLoading(){
+    Enhancer enhancer = new Enhancer();
+
+    enhancer.setSuperclass(PersonFixtureStep3.class);
+    enhancer.setCallback(new MethodLazyLoader());
+
+    Object proxy = enhancer.create();
+    PersonFixtureStep3 person = (PersonFixtureStep3) proxy;
+
+    assertThat(person.getName()).isEqualTo("제임스");
+    assertThat(person.getId()).isEqualTo(1L);
+    assertThat(person.getAge()).isEqualTo(21);
+    assertThat(person).isEqualTo(PersonInstances.첫번째사람);
+  }
+  public class MethodCallLogInterceptor implements MethodInterceptor {
+
+    @Override
+    public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy)
+        throws Throwable {
+      Object returnValue = proxy.invokeSuper(obj, args);
+
+      return returnValue.toString().toUpperCase();
+    }
+  }
+
+  public class MethodLazyLoader implements LazyLoader{
+
+    @Override
+    public Object loadObject() throws Exception {
+      return PersonInstances.첫번째사람;
+    }
+  }
+
+}


### PR DESCRIPTION
# 1단계



## 1. 요구사항 JOIN QUERY 만들기 --> 이거는 jpa로 query 일단 뽑아내기 join -> fetch join으로 나타내기
예시:

```sql
SELECT orders.id, orders.orderNumber, orderItems.id, orderItems.product, orderItems.quantity
FROM orders
JOIN orderItems on orders.id = orderItems.order_id
WHERE orders.id IN [1,2,3]
```

```sql
SELECT [<TABLE>.<COLUMNNAME> ...] -- COLUMN CLAUSE
FROM [<TABLE>] -- FROM
JOIN [<TABLE TO JOIN>] -- JOIN TABLE 
ON [<TABLE>.<COLUMN> = <TABLE TO JOIN>.<COLUMN FKEY>] -- JOIN ON CLAUSE
WHERE <TABLE>.<COLUMNNAME> IN [<VALUES>] -- WHERE CLAUSE
```

1. Column clause -> table 이름 앞에 붙이기
2. FROM -> table 이름
3. JOIN TABLE -> table to join 이름
4. JOIN ON CLAUSE ON Table의 id 와 TABLE TO JOIN 의 fk
5. WHERE CLAUSE  orders.id IN

인수 (table, list<column> columns, whereclause)
인수 2(tabletojoin, list<column> columns, fkey)


구현 요소 
1. JoinQueryBuilder -> JoinQuery(불변) 생성하기
    - Builder 객체들이 각각 select절을 만들고 where 절을 만들게 되는데 Clause 생성객체가 분리되어야한다.
    - 하지만 수정범위가 크니깐 JoinQuery를 미래에 리팩토링이 편하게 만들어 두자.
2. 아쉬운점
   추상화 요소들 (SELECT CLAUSE, WHERE CLAUSE, JOIN CLAUSE) 들에 대해서 너무 늦게 파악했다.
   
검증 요소
1. JOIN QUERY 생성 검증

## 2. Join Query 만들어서 Entity 화하기
select 이후에 eager이면 join fetch 진행 아니면 lazy


1. Loader에서 가져오는 로직 분기 필요 -> isRelation 이면 subEntity 필요해서 fetch join --> 얘도 분리가 필요하다고 강의에서 들은것같은데
   - 여기도 추상화가 필요하다
   - CollectionElementLoader(column, entity) -> 피드백 참고
     - rowmapper 따로 분기 
     - eager
     - lazy
     - join 문 2번이면 recursive인가?
   - 해당 객체의 상태값 잡기가 힘들다. 
     - EntityLoader 하위의 객체가 되면 안되는데 일단 Persister에서 분기시키기도 그래서 조금 어렵다....
   
2. EntityClass에 IsRelation을 만들거나 RelationalEntity를 만들어야되나 생각중이다.
   - Relation interface 로 emptyClass(null pattern) 와 RelationColumn(fetch type, collection type) 구현 필요
   - loader에서 사용해야 될 relation, joincolumn 정보 필요
   - IsRelation로 만들자
   - mapping은 조금더 봐야할듯
3. Rowmapper를 사용할때 여기서도 isRelation 값이 따로 필요한데 흠... oneToManyRowMapper를 따로 해야할지 생각필요하다
   - 이거 가져오는 로직이 있어서 다행이다. -> 피드백 참고
   - 얘도 따로 분기되야할듯 -> collection type 가져오는 부분이 단일 rowmapper 와 다르다.

힘들었던 부분:

1. 와 FOREIGN KEY HANDLING 진짜 헬이다....
   ENTITY RELATION 읽어와서 DB에 넣어줘야하는데
   테스트가 안된다.
   이부분은 그냥 INSERT로 넣어서 해야겠다.
2. relation이라는 meta정보를 이용하는데 애먹었고 해당 코드 변경이 legacy 코드에 영향을 주면서 수정 범위가 계속 넓어졌다.
너무 작은 변경에도 쉽게 허물어지는데 mapping 로직 확인 필요하다.

3. JOIN FETCH 로 구현해서 굉장히 빡셌다.


검증사항
1. Loader에서 CollectionEntity 로드 확인
2. EntityClass에서 Relationship 관련 컬럼확인
3. RowMapper에서 Entity 만드는것을 확인

리뷰사항

- 테스트 멱등성을 위해서 pk 키를 분리시켰습니다.

++++++++++++++++++++++++++++++++++++++++++++++++

# step 2 Lazyloading by Proxy 도 간단하게 같이 진행했습니다!

1. proxy 사용해서 대문자 변환시키기
   - 변환시키는것 검증시키기 -> 완료

2. Callback none 사용하기 -> 완료
3. Callback 하나더 사용하기 
