### PR TITLE
3단계 - OneToMany (FetchType.LAZY)

### DIFF
--- a/src/main/java/builder/dml/DMLUtil.java
+++ b/src/main/java/builder/dml/DMLUtil.java
@@ -1,3 +1,0 @@
-package builder.dml;
-public class DMLUtil {
-}

--- a/src/main/java/builder/dml/JoinEntityData.java
+++ b/src/main/java/builder/dml/JoinEntityData.java
@@ -10,7 +10,7 @@ public class JoinEntityData {
     private final Object joinColumnValue;
     private final EntityColumn joinColumnData;
     private final String alias;
-    private Class<?> clazz;
+    private final Class<?> clazz;
 
     public JoinEntityData(Class<?> clazz, String joinColumnName, Object joinColumnValue) {
         this.clazz = clazz;

--- a/src/main/java/persistence/EntityLoader.java
+++ b/src/main/java/persistence/EntityLoader.java
@@ -25,6 +25,7 @@ public class EntityLoader {
     }
 
     //Lazy 데이터를 전체 조회한다.
+    @SuppressWarnings("unchecked")
     public <T> List<T> findByIdLazy(JoinEntityData joinEntityData) {
         return (List<T>) jdbcTemplate.query(selectByIdQueryBuilder.buildLazyQuery(joinEntityData), resultSet -> EntityMapper.mapRow(resultSet, joinEntityData.getClazz()));
     }

--- a/src/test/java/persistence/EntityLoaderTest.java
+++ b/src/test/java/persistence/EntityLoaderTest.java
@@ -16,16 +16,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jdbc.JdbcTemplate;
 import org.assertj.core.groups.Tuple;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.sql.SQLException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 
 /*
@@ -94,12 +92,14 @@ class EntityLoaderTest {
 
         Order findOrder = this.entityLoader.find(Order.class, 1L);
 
-        assertThat(findOrder)
-                .extracting("id", "orderNumber")
-                .contains(1L, "1234");
-        assertThat(findOrder.getOrderItems())
-                .extracting("id", "orderId", "product", "quantity")
-                .containsExactly(tuple(1L, 1L, "테스트상품1", 1));
+        assertAll(
+                () -> assertThat(findOrder)
+                        .extracting("id", "orderNumber")
+                        .contains(1L, "1234"),
+                () -> assertThat(findOrder.getOrderItems())
+                        .extracting("id", "orderId", "product", "quantity")
+                        .containsExactly(tuple(1L, 1L, "테스트상품1", 1))
+        );
     }
 
     @DisplayName("Persist로 Order와 OrderItem을 저장 후 Lazy상태의 OrderItems를 조회한다.")
@@ -125,12 +125,14 @@ class EntityLoaderTest {
 
         OrderLazy findOrder = this.entityLoader.find(OrderLazy.class, 1L);
 
-        assertThat(findOrder)
-                .extracting("id", "orderNumber")
-                .contains(1L, "1234");
-        assertThat(findOrder.getOrderItems())
-                .extracting("id", "orderId", "product", "quantity")
-                .containsExactly(tuple(1L, 1L, "테스트상품1", 1));
+        assertAll(
+                () -> assertThat(findOrder)
+                        .extracting("id", "orderNumber")
+                        .contains(1L, "1234"),
+                () -> assertThat(findOrder.getOrderItems())
+                        .extracting("id", "orderId", "product", "quantity")
+                        .containsExactly(tuple(1L, 1L, "테스트상품1", 1))
+        );
     }
 
     private Person createPerson(int i) {


### PR DESCRIPTION
```
EntityData 는 제가 봤을때 JPA 스펙을 구현하기 위해 Entity 메타정보를 가지고 있는 객체라고 생각이 되는데요,
CRUD 모든 액션이 실행될 때 계속 생성하고 있는부분이 비용이 꽤 크다고 느껴집니다.
```

이 부분을 확인해보니 EntityData생성이 꼭 필요한 부분만 남아있어서 어디를 개선해야할지 감이 오지않네요ㅠ

일단 코드들 살펴보니 JoinEntity의 메소드들이 좀 공통적인 부분들도 있고 기능들이 많이 몰려있는 감이 들어서 메소드를 분리해서 메소드마다 간략하게 정리해봤습니다!

리뷰부탁드립니다!